### PR TITLE
Fix monotone sequences iterator

### DIFF
--- a/homotopy-core/src/factorization.rs
+++ b/homotopy-core/src/factorization.rs
@@ -56,7 +56,7 @@ pub fn factorize(
                 .collect();
 
             // find a particular monotone sequence which works
-            MonotoneIterator::new(false, constraints)
+            MonotoneIterator::new(false, &constraints)
                 .find_map(|h_mono| {
                     // Recurse on each monotone component
                     let mut cone_slices: Vec<Vec<Rewrite>> = vec![vec![]; t.size()];

--- a/homotopy-core/src/factorization.rs
+++ b/homotopy-core/src/factorization.rs
@@ -1,9 +1,9 @@
 use std::ops::Range;
 
+use crate::monotone::MonotoneIterator;
 use crate::Rewrite;
 use crate::{Diagram, Rewrite0};
 use crate::{Height, RewriteN};
-use crate::monotone::MonotoneIterator;
 use thiserror::Error;
 
 /// Given `Rewrite`s A -f> C <g- B, find some `Rewrite` A -h> B which factorises f = g ∘ h

--- a/homotopy-core/src/factorization.rs
+++ b/homotopy-core/src/factorization.rs
@@ -1,99 +1,10 @@
-use std::{cmp, ops::Range};
+use std::ops::Range;
 
 use crate::Rewrite;
 use crate::{Diagram, Rewrite0};
 use crate::{Height, RewriteN};
+use crate::monotone::MonotoneIterator;
 use thiserror::Error;
-
-/// Given a constraints vector of length $`n`$, this iterator generates all monotone
-/// (non-decreasing) sequences of $`n`$ digits, where each digit satisfies its corresponding
-/// constraint. Each constraint is a `Range<usize>`, a half-open range inclusive below and
-/// exclusive above, specifying the values which the digit with the same index in the output
-/// monotone sequence may take. The order of outputs is lexicographic.
-// this iterator is cyclic, *not* fused
-#[derive(Debug, Clone)]
-pub struct MonotoneSequences {
-    cur: Option<Vec<usize>>,
-
-    // invariant: ∀ x ∈ cur[end, len). x maxxed within its range
-    end: usize,
-    constraints: Vec<Range<usize>>, // digit-wise range constraints
-}
-
-#[allow(clippy::len_without_is_empty)]
-impl MonotoneSequences {
-    pub fn new(constraints: Vec<Range<usize>>) -> Self {
-        Self {
-            cur: None,
-            end: constraints.len(),
-            constraints,
-        }
-    }
-
-    /// The number of digits in the monotone sequence.
-    pub fn len(&self) -> usize {
-        self.constraints.len()
-    }
-}
-
-impl Iterator for MonotoneSequences {
-    type Item = Vec<usize>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let len = self.len();
-        match &mut self.cur {
-            None => {
-                // first monotone sequence is range.start for each digit
-                let mut min = Default::default();
-                let mut first = Vec::with_capacity(self.constraints.len());
-                for i in 0..self.constraints.len() {
-                    min = cmp::max(min, self.constraints[i].start);
-                    if min < self.constraints[i].end {
-                        first.push(min);
-                    } else {
-                        return None;
-                    }
-                }
-
-                // maintain invariant
-                self.end = first.len();
-                while self.end > 0 && first[self.end - 1] == self.constraints[self.end - 1].end - 1
-                {
-                    self.end -= 1;
-                }
-
-                self.cur = first.into();
-            }
-            Some(seq) => {
-                if self.end == 0 {
-                    self.cur = None;
-                } else {
-                    // increment last non-max digit
-                    let l = self.end - 1;
-                    seq[l] = cmp::min(seq[l] + 1, self.constraints[l].end - 1);
-
-                    if seq[l] == self.constraints[l].end - 1 {
-                        // maxxed seq[l] within its range
-                        self.end -= 1; // maintain invariant
-                    } else {
-                        for i in (self.end)..len {
-                            // preserve monotonicity for all values to the right
-                            seq[i] = cmp::max(seq[l], self.constraints[i].start);
-                            debug_assert!(seq[i] >= seq[l]);
-                        }
-
-                        // maintain invariant
-                        self.end = len;
-                        while seq[self.end - 1] == self.constraints[self.end - 1].end - 1 {
-                            self.end -= 1;
-                        }
-                    }
-                }
-            }
-        }
-        self.cur.clone()
-    }
-}
 
 /// Given `Rewrite`s A -f> C <g- B, find some `Rewrite` A -h> B which factorises f = g ∘ h
 // modulo trivial cases, this works by guessing a monotone function to underly h, and then recurse
@@ -145,7 +56,7 @@ pub fn factorize(
                 .collect();
 
             // find a particular monotone sequence which works
-            MonotoneSequences::new(constraints)
+            MonotoneIterator::new(false, constraints)
                 .find_map(|h_mono| {
                     // Recurse on each monotone component
                     let mut cone_slices: Vec<Vec<Rewrite>> = vec![vec![]; t.size()];
@@ -194,68 +105,4 @@ pub enum FactorizationError {
 
     #[error("failed to factorize")]
     Failed,
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn monotone_sequences() {
-        let ms_0_1_2 = MonotoneSequences::new(vec![0..2, 0..2]);
-        assert_eq!(ms_0_1_2.collect::<Vec<_>>(), [[0, 0], [0, 1], [1, 1]]);
-        let ms_0_3_3 = MonotoneSequences::new(vec![0..4, 0..4, 0..4]);
-        assert_eq!(
-            ms_0_3_3.collect::<Vec<_>>(),
-            [
-                [0, 0, 0],
-                [0, 0, 1],
-                [0, 0, 2],
-                [0, 0, 3],
-                [0, 1, 1],
-                [0, 1, 2],
-                [0, 1, 3],
-                [0, 2, 2],
-                [0, 2, 3],
-                [0, 3, 3],
-                [1, 1, 1],
-                [1, 1, 2],
-                [1, 1, 3],
-                [1, 2, 2],
-                [1, 2, 3],
-                [1, 3, 3],
-                [2, 2, 2],
-                [2, 2, 3],
-                [2, 3, 3],
-                [3, 3, 3]
-            ]
-        );
-        let ms_1_3_3 = MonotoneSequences::new(vec![1..4, 0..4, 1..4]);
-        assert_eq!(
-            ms_1_3_3.collect::<Vec<_>>(),
-            [
-                [1, 1, 1],
-                [1, 1, 2],
-                [1, 1, 3],
-                [1, 2, 2],
-                [1, 2, 3],
-                [1, 3, 3],
-                [2, 2, 2],
-                [2, 2, 3],
-                [2, 3, 3],
-                [3, 3, 3]
-            ]
-        );
-        // unsatisfiable constraints
-        let invalid_ms = MonotoneSequences::new(vec![1..2, 0..1]);
-        assert!(invalid_ms.collect::<Vec<_>>().is_empty());
-        // iterator should be cyclic
-        let mut ms_0_0_1 = MonotoneSequences::new(vec![0..1]);
-        dbg!(ms_0_0_1.clone().collect::<Vec<_>>());
-        assert_eq!(ms_0_0_1.next(), Some(vec![0]));
-        assert_eq!(ms_0_0_1.next(), None);
-        assert_eq!(ms_0_0_1.next(), Some(vec![0]));
-    }
-
-    // TODO: test factorize
 }

--- a/homotopy-core/src/lib.rs
+++ b/homotopy-core/src/lib.rs
@@ -54,6 +54,7 @@ pub mod expansion;
 pub mod factorization;
 pub mod graph;
 pub mod idx;
+pub mod monotone;
 pub mod normalization;
 pub mod projection;
 pub mod rewrite;

--- a/homotopy-core/src/monotone.rs
+++ b/homotopy-core/src/monotone.rs
@@ -1,0 +1,243 @@
+use std::cmp;
+use std::ops::Range;
+
+pub type Monotone = Vec<usize>;
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub struct MonotoneIterator {
+    cur: Option<Vec<usize>>,
+    pub strict: bool, // whether the sequences should be *strictly* monotone.
+    pub constraints: Vec<Range<usize>>, // element-wise range constraints for the sequences.
+}
+
+impl MonotoneIterator {
+    
+    pub fn new(strict: bool, constraints: Vec<Range<usize>>) -> Self {
+        let len = constraints.len();
+
+        // We need to tighten the constraints as the iterator assumes the constraints are tight.
+        let mut tight_constraints = constraints.clone();
+        if len > 1 {
+            let mut min = tight_constraints[0].start;
+            let mut max = tight_constraints[len - 1].end;
+            for i in 1..len {
+                if strict {
+                    min = cmp::max(min + 1, tight_constraints[i].start);
+                    max = cmp::min(max - 1, tight_constraints[len - i - 1].end);
+                } else {
+                    min = cmp::max(min, tight_constraints[i].start);
+                    max = cmp::min(max, tight_constraints[len - i - 1].end);
+                }
+                tight_constraints[i].start = min;
+                tight_constraints[len - i - 1].end = max;
+            }
+        }
+
+        Self {
+            cur: None,
+            strict,
+            constraints: tight_constraints,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.constraints.len()
+    }
+}
+
+impl Iterator for MonotoneIterator {
+
+    type Item = Vec<usize>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.cur {
+            None => {
+                // Set all elements to their minimal values.
+                let mut seq = Vec::with_capacity(self.len());
+                for i in 0..self.len() {
+                    // If the constraint is invalid, the iterator is empty.
+                    if self.constraints[i].is_empty() {
+                        return None
+                    } else {
+                        seq.push(self.constraints[i].start);
+                    }
+                }
+                self.cur = Some(seq);
+            },
+            Some(seq) => {
+                // Find the last non-maximal element.
+                let mut end = seq.len();
+                while end > 0 && seq[end - 1] == self.constraints[end - 1].end - 1 {
+                    end -= 1
+                }
+
+                if end == 0 {
+                    // All elements are maximal, so we have reached the end.
+                    return None
+                } else {
+                    // Increment the last non-maximal element.
+                    seq[end - 1] += 1;
+
+                    // Reset all elements to the right to their minimal values while preserving monotonicity.
+                    let mut min = seq[end - 1];
+                    for i in end..seq.len() {
+                        if self.strict {
+                            min = cmp::max(min + 1, self.constraints[i].start);
+                        } else {
+                            min = cmp::max(min, self.constraints[i].start);
+                        }
+                        assert!(min < self.constraints[i].end);
+                        seq[i] = min;
+                    }
+                }
+            },
+        }
+
+        self.cur.clone()
+    }
+}
+
+impl DoubleEndedIterator for MonotoneIterator {
+
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match &mut self.cur {
+            None => {
+                // Set all elements to their maximal values.
+                let mut seq = Vec::with_capacity(self.len());
+                for i in 0..self.len() {
+                    // If the constraint is invalid, the iterator is empty.
+                    if self.constraints[i].is_empty() {
+                        return None
+                    } else {
+                        seq.push(self.constraints[i].end - 1);
+                    }
+                }
+                self.cur = Some(seq);
+            },
+            Some(seq) => {
+                // Find the first non-minimal element.
+                let mut start = 0;
+                while start < seq.len() && seq[start] == self.constraints[start].start {
+                    start += 1
+                }
+
+                if start == seq.len() {
+                    // All elements are maximal, we have reached the end.
+                    return None
+                } else {
+                    // Decrement the first non-minimal element.
+                    seq[start] -= 1;
+
+                    // Reset all elements to the left to their maximal values while preserving monotonicity.
+                    let mut max = seq[start];
+                    for i in 0..start {
+                        if self.strict {
+                            max = cmp::min(max - 1, self.constraints[i].end - 1);
+                        } else {
+                            max = cmp::min(max, self.constraints[i].end - 1);
+                        }
+                        assert!(max >= self.constraints[i].start);
+                        seq[i] = max;
+                    }
+                }
+            },
+        }
+
+        self.cur.clone()
+    }
+}
+
+impl std::iter::FusedIterator for MonotoneIterator { }
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn monotone_sequences() {
+        let iterator0_1_2 = MonotoneIterator::new(false, vec![0..2, 0..2]);
+        assert_eq!(
+            iterator0_1_2.collect::<Vec<_>>(),
+            [
+                [0, 0],
+                [0, 1],
+                [1, 1],
+            ]
+        );
+
+        let strict_iterator0_1_2 = MonotoneIterator::new(true, vec![0..2, 0..2]);
+        assert_eq!(
+            strict_iterator0_1_2.collect::<Vec<_>>(),
+            [
+                [0, 1]
+            ]
+        );
+        
+        let iterator0_3_3 = MonotoneIterator::new(false, vec![0..4, 0..4, 0..4]);
+        assert_eq!(
+            iterator0_3_3.collect::<Vec<_>>(),
+            [
+                [0, 0, 0],
+                [0, 0, 1],
+                [0, 0, 2],
+                [0, 0, 3],
+                [0, 1, 1],
+                [0, 1, 2],
+                [0, 1, 3],
+                [0, 2, 2],
+                [0, 2, 3],
+                [0, 3, 3],
+                [1, 1, 1],
+                [1, 1, 2],
+                [1, 1, 3],
+                [1, 2, 2],
+                [1, 2, 3],
+                [1, 3, 3],
+                [2, 2, 2],
+                [2, 2, 3],
+                [2, 3, 3],
+                [3, 3, 3],
+            ]
+        );
+        let strict_iterator0_3_3 = MonotoneIterator::new(true, vec![0..4, 0..4, 0..4]);
+        assert_eq!(
+            strict_iterator0_3_3.collect::<Vec<_>>(),
+            [
+                [0, 1, 2],
+                [0, 1, 3],
+                [0, 2, 3],
+                [1, 2, 3],
+            ]
+        );
+
+        let iterator1_3_3 = MonotoneIterator::new(false, vec![1..4, 0..4, 1..4]);
+        assert_eq!(
+            iterator1_3_3.collect::<Vec<_>>(),
+            [
+                [1, 1, 1],
+                [1, 1, 2],
+                [1, 1, 3],
+                [1, 2, 2],
+                [1, 2, 3],
+                [1, 3, 3],
+                [2, 2, 2],
+                [2, 2, 3],
+                [2, 3, 3],
+                [3, 3, 3],
+            ]
+        );
+        let strict_iterator1_3_3 = MonotoneIterator::new(true
+            , vec![1..4, 0..4, 1..4]);
+        assert_eq!(
+            strict_iterator1_3_3.collect::<Vec<_>>(),
+            [
+                [1, 2, 3],
+            ]
+        );
+
+        // unsatisfiable constraints
+        let invalid_ms = MonotoneIterator::new(false, vec![1..2, 0..1]);
+        assert!(invalid_ms.collect::<Vec<_>>().is_empty());
+    }
+}

--- a/homotopy-core/src/monotone.rs
+++ b/homotopy-core/src/monotone.rs
@@ -11,7 +11,6 @@ pub struct MonotoneIterator {
 }
 
 impl MonotoneIterator {
-    
     pub fn new(strict: bool, constraints: Vec<Range<usize>>) -> Self {
         let len = constraints.len();
 
@@ -46,7 +45,6 @@ impl MonotoneIterator {
 }
 
 impl Iterator for MonotoneIterator {
-
     type Item = Vec<usize>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -57,13 +55,13 @@ impl Iterator for MonotoneIterator {
                 for i in 0..self.len() {
                     // If the constraint is invalid, the iterator is empty.
                     if self.constraints[i].is_empty() {
-                        return None
+                        return None;
                     } else {
                         seq.push(self.constraints[i].start);
                     }
                 }
                 self.cur = Some(seq);
-            },
+            }
             Some(seq) => {
                 // Find the last non-maximal element.
                 let mut end = seq.len();
@@ -73,7 +71,7 @@ impl Iterator for MonotoneIterator {
 
                 if end == 0 {
                     // All elements are maximal, so we have reached the end.
-                    return None
+                    return None;
                 } else {
                     // Increment the last non-maximal element.
                     seq[end - 1] += 1;
@@ -90,7 +88,7 @@ impl Iterator for MonotoneIterator {
                         seq[i] = min;
                     }
                 }
-            },
+            }
         }
 
         self.cur.clone()
@@ -98,7 +96,6 @@ impl Iterator for MonotoneIterator {
 }
 
 impl DoubleEndedIterator for MonotoneIterator {
-
     fn next_back(&mut self) -> Option<Self::Item> {
         match &mut self.cur {
             None => {
@@ -107,13 +104,13 @@ impl DoubleEndedIterator for MonotoneIterator {
                 for i in 0..self.len() {
                     // If the constraint is invalid, the iterator is empty.
                     if self.constraints[i].is_empty() {
-                        return None
+                        return None;
                     } else {
                         seq.push(self.constraints[i].end - 1);
                     }
                 }
                 self.cur = Some(seq);
-            },
+            }
             Some(seq) => {
                 // Find the first non-minimal element.
                 let mut start = 0;
@@ -123,7 +120,7 @@ impl DoubleEndedIterator for MonotoneIterator {
 
                 if start == seq.len() {
                     // All elements are maximal, we have reached the end.
-                    return None
+                    return None;
                 } else {
                     // Decrement the first non-minimal element.
                     seq[start] -= 1;
@@ -140,15 +137,14 @@ impl DoubleEndedIterator for MonotoneIterator {
                         seq[i] = max;
                     }
                 }
-            },
+            }
         }
 
         self.cur.clone()
     }
 }
 
-impl std::iter::FusedIterator for MonotoneIterator { }
-
+impl std::iter::FusedIterator for MonotoneIterator {}
 
 #[cfg(test)]
 mod test {
@@ -157,23 +153,11 @@ mod test {
     #[test]
     fn monotone_sequences() {
         let iterator0_1_2 = MonotoneIterator::new(false, vec![0..2, 0..2]);
-        assert_eq!(
-            iterator0_1_2.collect::<Vec<_>>(),
-            [
-                [0, 0],
-                [0, 1],
-                [1, 1],
-            ]
-        );
+        assert_eq!(iterator0_1_2.collect::<Vec<_>>(), [[0, 0], [0, 1], [1, 1]]);
 
         let strict_iterator0_1_2 = MonotoneIterator::new(true, vec![0..2, 0..2]);
-        assert_eq!(
-            strict_iterator0_1_2.collect::<Vec<_>>(),
-            [
-                [0, 1]
-            ]
-        );
-        
+        assert_eq!(strict_iterator0_1_2.collect::<Vec<_>>(), [[0, 1]]);
+
         let iterator0_3_3 = MonotoneIterator::new(false, vec![0..4, 0..4, 0..4]);
         assert_eq!(
             iterator0_3_3.collect::<Vec<_>>(),
@@ -203,12 +187,7 @@ mod test {
         let strict_iterator0_3_3 = MonotoneIterator::new(true, vec![0..4, 0..4, 0..4]);
         assert_eq!(
             strict_iterator0_3_3.collect::<Vec<_>>(),
-            [
-                [0, 1, 2],
-                [0, 1, 3],
-                [0, 2, 3],
-                [1, 2, 3],
-            ]
+            [[0, 1, 2], [0, 1, 3], [0, 2, 3], [1, 2, 3]]
         );
 
         let iterator1_3_3 = MonotoneIterator::new(false, vec![1..4, 0..4, 1..4]);
@@ -227,14 +206,8 @@ mod test {
                 [3, 3, 3],
             ]
         );
-        let strict_iterator1_3_3 = MonotoneIterator::new(true
-            , vec![1..4, 0..4, 1..4]);
-        assert_eq!(
-            strict_iterator1_3_3.collect::<Vec<_>>(),
-            [
-                [1, 2, 3],
-            ]
-        );
+        let strict_iterator1_3_3 = MonotoneIterator::new(true, vec![1..4, 0..4, 1..4]);
+        assert_eq!(strict_iterator1_3_3.collect::<Vec<_>>(), [[1, 2, 3]]);
 
         // unsatisfiable constraints
         let invalid_ms = MonotoneIterator::new(false, vec![1..2, 0..1]);


### PR DESCRIPTION
Fixes #136.

Also, you can restrict it to only generate *strictly* monotone sequences, which is necessary for cubicalisation.