### PR TITLE
Refactor graphs in `homotopy_core`

### DIFF
--- a/homotopy-common/src/graph.rs
+++ b/homotopy-common/src/graph.rs
@@ -4,9 +4,6 @@ use crate::{declare_idx, idx::IdxVec};
 
 declare_idx! {
     pub struct Node = usize;
-}
-
-declare_idx! {
     pub struct Edge = usize;
 }
 

--- a/homotopy-common/src/graph.rs
+++ b/homotopy-common/src/graph.rs
@@ -229,17 +229,17 @@ impl<V, E> Graph<V, E> {
     }
 
     #[inline]
-    pub fn nodes_keys(&self) -> impl Iterator<Item = Node> {
+    pub fn node_keys(&self) -> impl Iterator<Item = Node> {
         self.nodes.keys()
     }
 
     #[inline]
-    pub fn nodes_values(&self) -> impl Iterator<Item = &NodeData<V>> {
+    pub fn node_values(&self) -> impl Iterator<Item = &NodeData<V>> {
         self.nodes.values()
     }
 
     #[inline]
-    pub fn nodes_values_mut(&mut self) -> impl Iterator<Item = &mut NodeData<V>> {
+    pub fn node_values_mut(&mut self) -> impl Iterator<Item = &mut NodeData<V>> {
         self.nodes.values_mut()
     }
 
@@ -254,17 +254,17 @@ impl<V, E> Graph<V, E> {
     }
 
     #[inline]
-    pub fn edges_keys(&self) -> impl Iterator<Item = Edge> {
+    pub fn edge_keys(&self) -> impl Iterator<Item = Edge> {
         self.edges.keys()
     }
 
     #[inline]
-    pub fn edges_values(&self) -> impl Iterator<Item = &EdgeData<E>> {
+    pub fn edge_values(&self) -> impl Iterator<Item = &EdgeData<E>> {
         self.edges.values()
     }
 
     #[inline]
-    pub fn edges_values_mut(&mut self) -> impl Iterator<Item = &mut EdgeData<E>> {
+    pub fn edge_values_mut(&mut self) -> impl Iterator<Item = &mut EdgeData<E>> {
         self.edges.values_mut()
     }
 

--- a/homotopy-common/src/graph.rs
+++ b/homotopy-common/src/graph.rs
@@ -1,0 +1,351 @@
+use std::ops::{Deref, DerefMut, Index, IndexMut};
+
+use crate::{declare_idx, idx::IdxVec};
+
+declare_idx! {
+    pub struct Node = usize;
+}
+
+declare_idx! {
+    pub struct Edge = usize;
+}
+
+#[derive(Clone, Debug)]
+pub struct NodeData<T> {
+    weight: T,
+    incoming: Vec<Edge>,
+    outgoing: Vec<Edge>,
+}
+
+impl<T> NodeData<T> {
+    #[inline]
+    pub fn inner(&self) -> &T {
+        &self.weight
+    }
+
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.weight
+    }
+
+    #[inline]
+    pub fn into_inner(self) -> T {
+        self.weight
+    }
+
+    #[inline]
+    pub fn map<F, U>(self, f: F) -> NodeData<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        NodeData {
+            weight: f(self.weight),
+            incoming: self.incoming,
+            outgoing: self.outgoing,
+        }
+    }
+
+    #[inline]
+    pub fn incoming_edges(&self) -> impl Iterator<Item = Edge> + '_ {
+        self.incoming.iter().copied()
+    }
+
+    #[inline]
+    pub fn outgoing_edges(&self) -> impl Iterator<Item = Edge> + '_ {
+        self.outgoing.iter().copied()
+    }
+}
+
+impl<T> Deref for NodeData<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.inner()
+    }
+}
+
+impl<T> DerefMut for NodeData<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner_mut()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct EdgeData<T> {
+    weight: T,
+    endpoints: [Node; 2],
+}
+
+impl<T> EdgeData<T> {
+    #[inline]
+    pub fn inner(&self) -> &T {
+        &self.weight
+    }
+
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.weight
+    }
+
+    #[inline]
+    pub fn into_inner(self) -> T {
+        self.weight
+    }
+
+    #[inline]
+    pub fn map<F, U>(self, f: F) -> EdgeData<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        EdgeData {
+            weight: f(self.weight),
+            endpoints: self.endpoints,
+        }
+    }
+
+    #[inline]
+    pub fn source(&self) -> Node {
+        self.endpoints[0]
+    }
+
+    #[inline]
+    pub fn target(&self) -> Node {
+        self.endpoints[1]
+    }
+}
+
+impl<T> Deref for EdgeData<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.inner()
+    }
+}
+
+impl<T> DerefMut for EdgeData<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.inner_mut()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Graph<V, E> {
+    nodes: IdxVec<Node, NodeData<V>>,
+    edges: IdxVec<Edge, EdgeData<E>>,
+}
+
+impl<V, E> Graph<V, E> {
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            nodes: IdxVec::new(),
+            edges: IdxVec::new(),
+        }
+    }
+
+    #[inline]
+    pub fn add_node(&mut self, v: V) -> Node {
+        self.nodes.push(NodeData {
+            weight: v,
+            incoming: vec![],
+            outgoing: vec![],
+        })
+    }
+
+    #[inline]
+    pub fn add_edge(&mut self, s: Node, t: Node, e: E) -> Edge {
+        let id = self.edges.push(EdgeData {
+            weight: e,
+            endpoints: [s, t],
+        });
+        self.nodes[s].outgoing.push(id);
+        self.nodes[t].incoming.push(id);
+        id
+    }
+
+    #[inline]
+    pub fn with_node<F, U>(&self, node: Node, f: F) -> U
+    where
+        F: FnOnce(&NodeData<V>) -> U,
+    {
+        f(&self.nodes[node])
+    }
+
+    #[inline]
+    pub fn with_edge<F, U>(&self, edge: Edge, f: F) -> U
+    where
+        F: FnOnce(&EdgeData<E>) -> U,
+    {
+        f(&self.edges[edge])
+    }
+
+    #[inline]
+    pub fn with_node_mut<F, U>(&mut self, node: Node, f: F) -> U
+    where
+        F: FnOnce(&mut NodeData<V>) -> U,
+    {
+        f(&mut self.nodes[node])
+    }
+
+    #[inline]
+    pub fn with_edge_mut<F, U>(&mut self, edge: Edge, f: F) -> U
+    where
+        F: FnOnce(&mut EdgeData<E>) -> U,
+    {
+        f(&mut self.edges[edge])
+    }
+
+    #[inline]
+    pub fn map<F, G, V2, E2>(self, mut f: F, mut g: G) -> Graph<V2, E2>
+    where
+        F: FnMut(V) -> V2,
+        G: FnMut(E) -> E2,
+    {
+        Graph {
+            nodes: self.nodes.map(|nd| nd.map(|x| f(x))),
+            edges: self.edges.map(|ed| ed.map(|x| g(x))),
+        }
+    }
+
+    #[inline]
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    #[inline]
+    pub fn edge_count(&self) -> usize {
+        self.edges.len()
+    }
+
+    #[inline]
+    pub fn nodes(&self) -> impl Iterator<Item = (Node, &NodeData<V>)> {
+        self.nodes.iter()
+    }
+
+    #[inline]
+    pub fn nodes_mut(&mut self) -> impl Iterator<Item = (Node, &mut NodeData<V>)> {
+        self.nodes.iter_mut()
+    }
+
+    #[inline]
+    pub fn nodes_keys(&self) -> impl Iterator<Item = Node> {
+        self.nodes.keys()
+    }
+
+    #[inline]
+    pub fn nodes_values(&self) -> impl Iterator<Item = &NodeData<V>> {
+        self.nodes.values()
+    }
+
+    #[inline]
+    pub fn nodes_values_mut(&mut self) -> impl Iterator<Item = &mut NodeData<V>> {
+        self.nodes.values_mut()
+    }
+
+    #[inline]
+    pub fn edges(&self) -> impl Iterator<Item = (Edge, &EdgeData<E>)> {
+        self.edges.iter()
+    }
+
+    #[inline]
+    pub fn edges_mut(&mut self) -> impl Iterator<Item = (Edge, &mut EdgeData<E>)> {
+        self.edges.iter_mut()
+    }
+
+    #[inline]
+    pub fn edges_keys(&self) -> impl Iterator<Item = Edge> {
+        self.edges.keys()
+    }
+
+    #[inline]
+    pub fn edges_values(&self) -> impl Iterator<Item = &EdgeData<E>> {
+        self.edges.values()
+    }
+
+    #[inline]
+    pub fn edges_values_mut(&mut self) -> impl Iterator<Item = &mut EdgeData<E>> {
+        self.edges.values_mut()
+    }
+
+    #[inline]
+    pub fn node_weight(&self, node: Node) -> Option<&V> {
+        self.nodes.get(node).map(NodeData::inner)
+    }
+
+    #[inline]
+    pub fn edge_weight(&self, edge: Edge) -> Option<&E> {
+        self.edges.get(edge).map(EdgeData::inner)
+    }
+
+    #[inline]
+    pub fn node_weight_mut(&mut self, node: Node) -> Option<&mut V> {
+        self.nodes.get_mut(node).map(NodeData::inner_mut)
+    }
+
+    #[inline]
+    pub fn edge_weight_mut(&mut self, edge: Edge) -> Option<&mut E> {
+        self.edges.get_mut(edge).map(EdgeData::inner_mut)
+    }
+
+    #[inline]
+    pub fn source(&self, edge: Edge) -> Node {
+        self.edges[edge].source()
+    }
+
+    #[inline]
+    pub fn target(&self, edge: Edge) -> Node {
+        self.edges[edge].target()
+    }
+
+    #[inline]
+    pub fn incoming_edges(&self, node: Node) -> impl Iterator<Item = Edge> + '_ {
+        self.nodes[node].incoming_edges()
+    }
+
+    #[inline]
+    pub fn outgoing_edges(&self, node: Node) -> impl Iterator<Item = Edge> + '_ {
+        self.nodes[node].outgoing_edges()
+    }
+}
+
+impl<V, E> Default for Graph<V, E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<V, E> Index<Node> for Graph<V, E> {
+    type Output = V;
+
+    #[inline]
+    fn index(&self, index: Node) -> &Self::Output {
+        self.nodes[index].inner()
+    }
+}
+
+impl<V, E> Index<Edge> for Graph<V, E> {
+    type Output = E;
+
+    #[inline]
+    fn index(&self, index: Edge) -> &Self::Output {
+        self.edges[index].inner()
+    }
+}
+
+impl<V, E> IndexMut<Node> for Graph<V, E> {
+    #[inline]
+    fn index_mut(&mut self, index: Node) -> &mut Self::Output {
+        self.nodes[index].inner_mut()
+    }
+}
+
+impl<V, E> IndexMut<Edge> for Graph<V, E> {
+    #[inline]
+    fn index_mut(&mut self, index: Edge) -> &mut Self::Output {
+        self.edges[index].inner_mut()
+    }
+}

--- a/homotopy-common/src/lib.rs
+++ b/homotopy-common/src/lib.rs
@@ -43,6 +43,7 @@
 )]
 
 pub mod dense;
+pub mod graph;
 pub mod idx;
 pub mod tree;
 pub mod union_find;

--- a/homotopy-common/src/union_find.rs
+++ b/homotopy-common/src/union_find.rs
@@ -24,9 +24,9 @@ impl<I> UnionFind<I>
 where
     I: Idx,
 {
-    pub fn new<T>(data: &IdxVec<I, T>) -> Self {
+    pub fn new(len: usize) -> Self {
         Self {
-            forest: data.keys().map(NodeData::new).collect(),
+            forest: (0..len).map(I::new).map(NodeData::new).collect(),
         }
     }
 

--- a/homotopy-core/src/cubicalisation.rs
+++ b/homotopy-core/src/cubicalisation.rs
@@ -78,7 +78,7 @@ impl CubicalGraph {
     }
 
     fn parallelise_directed(&self, bias: Bias, direction: Direction) -> Option<Self> {
-        if self.inner.edges_values().all(|edge| edge.is_parallel()) {
+        if self.inner.edge_values().all(|edge| edge.is_parallel()) {
             Some(self.clone())
         } else {
             match direction {
@@ -143,7 +143,7 @@ impl SingularExpansion {
         // Construct a monotone iterator for every edge and identify the trivial edges.
         let mut iterators: IdxVec<Edge, (MonotoneIterator, bool)> =
             IdxVec::with_capacity(graph.inner.edge_count());
-        for edge in graph.inner.edges_values() {
+        for edge in graph.inner.edge_values() {
             let rewrite: &CubicalRewriteN = (edge.inner()).try_into()?;
 
             let source_weights = &weights[edge.source()];
@@ -190,7 +190,7 @@ impl SingularExpansion {
         let mut combined_iterators: Vec<MonotoneIterator> = vec![];
         let mut indices: IdxVec<Edge, Option<usize>> =
             IdxVec::from_iter(vec![None; graph.inner.edge_count()]);
-        for e in graph.inner.edges_keys() {
+        for e in graph.inner.edge_keys() {
             let key = union_find.find(e);
             let iterator = &iterators[e].0;
             match indices[key] {
@@ -473,7 +473,7 @@ impl RegularExpansion {
         // Construct a monotone iterator for every edge and identify the trivial edges.
         let mut iterators: IdxVec<Edge, (MonotoneIterator, bool)> =
             IdxVec::with_capacity(graph.inner.edge_count());
-        for edge in graph.inner.edges_values() {
+        for edge in graph.inner.edge_values() {
             let rewrite: &CubicalRewriteN = (edge.inner()).try_into()?;
 
             let source_weights = &weights[edge.source()];
@@ -520,7 +520,7 @@ impl RegularExpansion {
         let mut combined_iterators: Vec<MonotoneIterator> = vec![];
         let mut indices: IdxVec<Edge, Option<usize>> =
             IdxVec::from_iter(vec![None; graph.inner.edge_count()]);
-        for e in graph.inner.edges_keys() {
+        for e in graph.inner.edge_keys() {
             let key = union_find.find(e);
             let iterator = &iterators[e].0;
             match indices[key] {
@@ -972,7 +972,7 @@ impl CubicalGraph {
         let mut labels = IdxVec::new();
         let mut internal_labels = IdxVec::new();
 
-        for n in graph.nodes_keys() {
+        for n in graph.node_keys() {
             let label = self.label(n);
             for index in &self.internal_labels[n] {
                 labels.push(mk_coord(label, *index));

--- a/homotopy-core/src/graph.rs
+++ b/homotopy-core/src/graph.rs
@@ -1,178 +1,205 @@
 use std::convert::{Into, TryInto};
 
-use petgraph::Graph;
+use homotopy_common::{
+    graph::{Graph, Node},
+    idx::IdxVec,
+};
 
 use crate::{
     common::{Boundary, DimensionError, Height, SliceIndex},
     diagram::{Diagram, DiagramN},
-    rewrite::{Rewrite, RewriteN},
+    rewrite::{DefaultAllocator, GenericRewrite, GenericRewriteN, RewriteAllocator},
 };
 
-#[derive(Debug, Clone)]
-pub struct GraphBuilder<K> {
-    pub nodes: Vec<(K, Diagram)>,
-    pub edges: Vec<(usize, usize, Rewrite)>,
+type Coord = Vec<SliceIndex>;
+
+fn mk_coord<I>(coord: &[SliceIndex], index: I) -> Coord
+where
+    I: Into<SliceIndex>,
+{
+    let mut coord = coord.to_owned();
+    coord.push(index.into());
+    coord
+}
+
+pub type SliceGraph<A = DefaultAllocator> = Graph<(Coord, Diagram), GenericRewrite<A>>;
+
+#[derive(Clone, Debug)]
+pub struct GraphBuilder<A = DefaultAllocator>
+where
+    A: RewriteAllocator,
+{
+    graph: SliceGraph<A>,
     dimension: usize,
 }
 
-impl<K> GraphBuilder<K> {
-    pub fn new(key: K, diagram: Diagram) -> Self {
-        Self {
-            dimension: diagram.dimension(),
-            nodes: vec![(key, diagram)],
-            edges: vec![],
-        }
-    }
-}
-
-impl<K> GraphBuilder<K> {
-    pub fn build(self) -> Graph<(K, Diagram), Rewrite> {
-        let mut graph: Graph<(K, Diagram), Rewrite> =
-            Graph::with_capacity(self.nodes.len(), self.edges.len());
-
-        for node in self.nodes {
-            graph.add_node(node);
-        }
-
-        for (source, target, rewrite) in self.edges {
-            let source = (source as u32).into();
-            let target = (target as u32).into();
-            graph.add_edge(source, target, rewrite);
-        }
-
-        graph
-    }
-}
-
-impl<K> GraphBuilder<K>
+impl<A, T> GraphBuilder<A>
 where
-    K: Clone,
+    A: RewriteAllocator<Payload = T>,
+    T: Default,
 {
-    pub fn explode<R, F>(self, f: F) -> Result<GraphBuilder<R>, DimensionError>
-    where
-        F: Fn(SliceIndex, K) -> R + Copy,
-    {
+    pub fn new(diagram: Diagram) -> Self {
+        let dimension = diagram.dimension();
+
+        let mut graph = Graph::new();
+        graph.add_node((vec![], diagram));
+
+        Self { graph, dimension }
+    }
+
+    pub fn build(self) -> SliceGraph<A> {
+        self.graph
+    }
+
+    pub fn explode(&self) -> Result<Self, DimensionError> {
         use Height::{Regular, Singular};
 
         if self.dimension == 0 {
             return Err(DimensionError);
         }
 
-        let mut nodes_exploded: Vec<(R, Diagram)> = Vec::new();
-        let mut edges_exploded: Vec<(usize, usize, Rewrite)> = Vec::new();
+        let mut graph = Graph::new();
 
-        // For every node index in the original graph, we record the index in `nodes_exploded` at
-        // which the slices of that node start. This allows us to find the index again when
-        // constructing the edges of the exploded graph.
-        let mut nodes_indices: Vec<usize> = Vec::new();
+        // Maps every node in the original graph to its slices in the exploded graph.
+        let mut node_to_slices: IdxVec<Node, Vec<Node>> =
+            IdxVec::with_capacity(self.graph.node_count());
 
-        for (key, node) in self.nodes {
-            let nodes_index_start = nodes_exploded.len();
-            nodes_indices.push(nodes_index_start);
-            let node: DiagramN = node.try_into()?;
+        for nd in self.graph.nodes_values() {
+            let coord: &Coord = &nd.0;
+            let diagram: &DiagramN = (&nd.1).try_into()?;
+
+            let mut slices = Vec::with_capacity(diagram.size() * 2 + 3);
 
             // Source slice
-            nodes_exploded.push({
-                let slice_key = f(Boundary::Source.into(), key.clone());
-                let slice = node.source();
-                (slice_key, slice)
-            });
+            slices.push(graph.add_node({
+                let slice_coord = mk_coord(coord, Boundary::Source);
+                let slice = diagram.source();
+                (slice_coord, slice)
+            }));
 
             // Interior slices
-            for (i, slice) in node.slices().enumerate() {
-                let height = Height::from_int(i).into();
-                let slice_key = f(height, key.clone());
-                nodes_exploded.push((slice_key, slice));
+            for (i, slice) in diagram.slices().enumerate() {
+                let slice_coord = mk_coord(coord, Height::from_int(i));
+                slices.push(graph.add_node((slice_coord, slice)));
             }
 
             // Target slice
-            nodes_exploded.push({
-                let slice_key = f(Boundary::Target.into(), key.clone());
-                let slice = nodes_exploded.last().unwrap().1.clone();
-                (slice_key, slice)
-            });
+            slices.push(graph.add_node({
+                let slice_coord = mk_coord(coord, Boundary::Target);
+                let slice = diagram.target();
+                (slice_coord, slice)
+            }));
 
             // Identity rewrite from source slice
-            edges_exploded.push((
-                nodes_index_start,
-                nodes_index_start + 1,
-                Rewrite::identity(self.dimension - 1),
-            ));
+            graph.add_edge(
+                slices[0],
+                slices[1],
+                GenericRewrite::identity(self.dimension - 1),
+            );
 
             // Rewrites between interior slices
-            for (i, cospan) in node.cospans().iter().enumerate() {
-                edges_exploded.push((
-                    nodes_index_start + Regular(i).to_int() + 1,
-                    nodes_index_start + Singular(i).to_int() + 1,
-                    cospan.forward.clone(),
-                ));
+            for (i, cospan) in diagram.cospans().iter().enumerate() {
+                graph.add_edge(
+                    slices[Regular(i).to_int() + 1],
+                    slices[Singular(i).to_int() + 1],
+                    cospan.forward.convert(),
+                );
 
-                edges_exploded.push((
-                    nodes_index_start + Regular(i + 1).to_int() + 1,
-                    nodes_index_start + Singular(i).to_int() + 1,
-                    cospan.backward.clone(),
-                ));
+                graph.add_edge(
+                    slices[Regular(i + 1).to_int() + 1],
+                    slices[Singular(i).to_int() + 1],
+                    cospan.backward.convert(),
+                );
             }
 
             // Identity rewrite from target slice
-            edges_exploded.push((
-                nodes_index_start + node.size() * 2 + 2,
-                nodes_index_start + node.size() * 2 + 1,
-                Rewrite::identity(self.dimension - 1),
-            ));
+            graph.add_edge(
+                slices[diagram.size() * 2 + 2],
+                slices[diagram.size() * 2 + 1],
+                GenericRewrite::identity(self.dimension - 1),
+            );
+
+            node_to_slices.push(slices);
         }
 
-        // We push a final index so that the length of any node's contribution to `nodes_exploded`
-        // can be computed by subtracting the node's index from that of the next node.
-        nodes_indices.push(nodes_exploded.len());
+        for ed in self.graph.edges_values() {
+            let rewrite: &GenericRewriteN<_> = ed.inner().try_into()?;
 
-        for (source, target, rewrite) in self.edges {
-            let rewrite: RewriteN = rewrite.try_into()?;
-
-            let source_index = nodes_indices[source];
-            let source_size = nodes_indices[source + 1] - source_index;
-            let target_index = nodes_indices[target];
-            let target_size = nodes_indices[target + 1] - target_index;
+            let source_slices = &node_to_slices[ed.source()];
+            let source_size = source_slices.len();
+            let target_slices = &node_to_slices[ed.target()];
+            let target_size = target_slices.len();
 
             // Identity rewrite between source slices
-            edges_exploded.push((
-                source_index,
-                target_index,
-                Rewrite::identity(self.dimension - 1),
-            ));
+            graph.add_edge(
+                source_slices[0],
+                target_slices[0],
+                GenericRewrite::identity(self.dimension - 1),
+            );
 
             // Identity rewrite between target slices
-            edges_exploded.push((
-                source_index + source_size - 1,
-                target_index + target_size - 1,
-                Rewrite::identity(self.dimension - 1),
-            ));
+            graph.add_edge(
+                source_slices[source_size - 1],
+                target_slices[target_size - 1],
+                GenericRewrite::identity(self.dimension - 1),
+            );
 
             // Singular slices
             for source_height in 0..(source_size - 3) / 2 {
                 let target_height = rewrite.singular_image(source_height);
-                edges_exploded.push((
-                    source_index + Singular(source_height).to_int() + 1,
-                    target_index + Singular(target_height).to_int() + 1,
+                graph.add_edge(
+                    source_slices[Singular(source_height).to_int() + 1],
+                    target_slices[Singular(target_height).to_int() + 1],
                     rewrite.slice(source_height),
-                ));
+                );
             }
 
             // Regular slices
             for target_height in 0..(target_size - 1) / 2 {
                 let source_height = rewrite.regular_image(target_height);
-                edges_exploded.push((
-                    source_index + Regular(source_height).to_int() + 1,
-                    target_index + Regular(target_height).to_int() + 1,
-                    Rewrite::identity(self.dimension - 1),
-                ));
+                graph.add_edge(
+                    source_slices[Regular(source_height).to_int() + 1],
+                    target_slices[Regular(target_height).to_int() + 1],
+                    GenericRewrite::identity(self.dimension - 1),
+                );
             }
         }
 
-        Ok(GraphBuilder {
-            nodes: nodes_exploded,
-            edges: edges_exploded,
+        Ok(Self {
+            graph,
             dimension: self.dimension - 1,
         })
+    }
+}
+
+pub struct TopologicalSort(Vec<Node>);
+
+impl TopologicalSort {
+    pub fn new<A>(graph: &SliceGraph<A>) -> Self
+    where
+        A: RewriteAllocator,
+    {
+        let mut nodes: Vec<Node> = graph.nodes_keys().collect();
+        nodes.sort_by_cached_key(|&n| {
+            graph[n]
+                .0
+                .iter()
+                .map(|&index| match index {
+                    SliceIndex::Boundary(_) => -1,
+                    SliceIndex::Interior(Height::Regular(_)) => 0,
+                    SliceIndex::Interior(Height::Singular(_)) => 1,
+                })
+                .sum::<i32>()
+        });
+        Self(nodes)
+    }
+}
+
+impl IntoIterator for TopologicalSort {
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    type Item = Node;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }

--- a/homotopy-core/src/graph.rs
+++ b/homotopy-core/src/graph.rs
@@ -60,7 +60,7 @@ where
     // Maps every node in the original graph to its slices in the exploded graph.
     let mut node_to_slices: IdxVec<Node, Vec<Node>> = IdxVec::with_capacity(graph.node_count());
 
-    for nd in graph.nodes_values() {
+    for nd in graph.node_values() {
         let coord: &Coord = &nd.0;
         let diagram: &DiagramN = (&nd.1).try_into()?;
 
@@ -118,7 +118,7 @@ where
         node_to_slices.push(slices);
     }
 
-    for ed in graph.edges_values() {
+    for ed in graph.edge_values() {
         let rewrite: &GenericRewriteN<_> = ed.inner().try_into()?;
 
         let source_slices = &node_to_slices[ed.source()];
@@ -167,7 +167,7 @@ impl TopologicalSort {
     where
         A: RewriteAllocator,
     {
-        let mut nodes: Vec<Node> = graph.nodes_keys().collect();
+        let mut nodes: Vec<Node> = graph.node_keys().collect();
         nodes.sort_by_cached_key(|&n| {
             graph[n]
                 .0

--- a/homotopy-core/src/graph.rs
+++ b/homotopy-core/src/graph.rs
@@ -24,152 +24,143 @@ where
 
 pub type SliceGraph<A = DefaultAllocator> = Graph<(Coord, Diagram), GenericRewrite<A>>;
 
-#[derive(Clone, Debug)]
-pub struct GraphBuilder<A = DefaultAllocator>
-where
-    A: RewriteAllocator,
-{
-    graph: SliceGraph<A>,
-    dimension: usize,
-}
+pub struct GraphBuilder;
 
-impl<A, T> GraphBuilder<A>
-where
-    A: RewriteAllocator<Payload = T>,
-    T: Default,
-{
-    pub fn new(diagram: Diagram) -> Self {
-        let dimension = diagram.dimension();
-
-        let mut graph = Graph::new();
-        graph.add_node((vec![], diagram));
-
-        Self { graph, dimension }
-    }
-
-    pub fn build(self) -> SliceGraph<A> {
-        self.graph
-    }
-
-    pub fn explode(&self) -> Result<Self, DimensionError> {
-        use Height::{Regular, Singular};
-
-        if self.dimension == 0 {
+impl GraphBuilder {
+    pub fn build<A, T>(diagram: Diagram, depth: usize) -> Result<SliceGraph<A>, DimensionError>
+    where
+        A: RewriteAllocator<Payload = T>,
+        T: Default,
+    {
+        if depth > diagram.dimension() {
             return Err(DimensionError);
         }
 
         let mut graph = Graph::new();
+        graph.add_node((vec![], diagram));
 
-        // Maps every node in the original graph to its slices in the exploded graph.
-        let mut node_to_slices: IdxVec<Node, Vec<Node>> =
-            IdxVec::with_capacity(self.graph.node_count());
-
-        for nd in self.graph.nodes_values() {
-            let coord: &Coord = &nd.0;
-            let diagram: &DiagramN = (&nd.1).try_into()?;
-
-            let mut slices = Vec::with_capacity(diagram.size() * 2 + 3);
-
-            // Source slice
-            slices.push(graph.add_node({
-                let slice_coord = mk_coord(coord, Boundary::Source);
-                let slice = diagram.source();
-                (slice_coord, slice)
-            }));
-
-            // Interior slices
-            for (i, slice) in diagram.slices().enumerate() {
-                let slice_coord = mk_coord(coord, Height::from_int(i));
-                slices.push(graph.add_node((slice_coord, slice)));
-            }
-
-            // Target slice
-            slices.push(graph.add_node({
-                let slice_coord = mk_coord(coord, Boundary::Target);
-                let slice = diagram.target();
-                (slice_coord, slice)
-            }));
-
-            // Identity rewrite from source slice
-            graph.add_edge(
-                slices[0],
-                slices[1],
-                GenericRewrite::identity(self.dimension - 1),
-            );
-
-            // Rewrites between interior slices
-            for (i, cospan) in diagram.cospans().iter().enumerate() {
-                graph.add_edge(
-                    slices[Regular(i).to_int() + 1],
-                    slices[Singular(i).to_int() + 1],
-                    cospan.forward.convert(),
-                );
-
-                graph.add_edge(
-                    slices[Regular(i + 1).to_int() + 1],
-                    slices[Singular(i).to_int() + 1],
-                    cospan.backward.convert(),
-                );
-            }
-
-            // Identity rewrite from target slice
-            graph.add_edge(
-                slices[diagram.size() * 2 + 2],
-                slices[diagram.size() * 2 + 1],
-                GenericRewrite::identity(self.dimension - 1),
-            );
-
-            node_to_slices.push(slices);
+        for _ in 0..depth {
+            graph = explode(&graph)?;
         }
 
-        for ed in self.graph.edges_values() {
-            let rewrite: &GenericRewriteN<_> = ed.inner().try_into()?;
-
-            let source_slices = &node_to_slices[ed.source()];
-            let source_size = source_slices.len();
-            let target_slices = &node_to_slices[ed.target()];
-            let target_size = target_slices.len();
-
-            // Identity rewrite between source slices
-            graph.add_edge(
-                source_slices[0],
-                target_slices[0],
-                GenericRewrite::identity(self.dimension - 1),
-            );
-
-            // Identity rewrite between target slices
-            graph.add_edge(
-                source_slices[source_size - 1],
-                target_slices[target_size - 1],
-                GenericRewrite::identity(self.dimension - 1),
-            );
-
-            // Singular slices
-            for source_height in 0..(source_size - 3) / 2 {
-                let target_height = rewrite.singular_image(source_height);
-                graph.add_edge(
-                    source_slices[Singular(source_height).to_int() + 1],
-                    target_slices[Singular(target_height).to_int() + 1],
-                    rewrite.slice(source_height),
-                );
-            }
-
-            // Regular slices
-            for target_height in 0..(target_size - 1) / 2 {
-                let source_height = rewrite.regular_image(target_height);
-                graph.add_edge(
-                    source_slices[Regular(source_height).to_int() + 1],
-                    target_slices[Regular(target_height).to_int() + 1],
-                    GenericRewrite::identity(self.dimension - 1),
-                );
-            }
-        }
-
-        Ok(Self {
-            graph,
-            dimension: self.dimension - 1,
-        })
+        Ok(graph)
     }
+}
+
+pub fn explode<A, T>(graph: &SliceGraph<A>) -> Result<SliceGraph<A>, DimensionError>
+where
+    A: RewriteAllocator<Payload = T>,
+    T: Default,
+{
+    use Height::{Regular, Singular};
+
+    let mut exploded_graph: SliceGraph<A> = Graph::new();
+
+    // Maps every node in the original graph to its slices in the exploded graph.
+    let mut node_to_slices: IdxVec<Node, Vec<Node>> = IdxVec::with_capacity(graph.node_count());
+
+    for nd in graph.nodes_values() {
+        let coord: &Coord = &nd.0;
+        let diagram: &DiagramN = (&nd.1).try_into()?;
+
+        let mut slices = Vec::with_capacity(diagram.size() * 2 + 3);
+
+        // Source slice
+        slices.push(exploded_graph.add_node({
+            let slice_coord = mk_coord(coord, Boundary::Source);
+            let slice = diagram.source();
+            (slice_coord, slice)
+        }));
+
+        // Interior slices
+        for (i, slice) in diagram.slices().enumerate() {
+            let slice_coord = mk_coord(coord, Height::from_int(i));
+            slices.push(exploded_graph.add_node((slice_coord, slice)));
+        }
+
+        // Target slice
+        slices.push(exploded_graph.add_node({
+            let slice_coord = mk_coord(coord, Boundary::Target);
+            let slice = diagram.target();
+            (slice_coord, slice)
+        }));
+
+        // Identity rewrite from source slice
+        exploded_graph.add_edge(
+            slices[0],
+            slices[1],
+            GenericRewrite::identity(diagram.dimension() - 1),
+        );
+
+        // Rewrites between interior slices
+        for (i, cospan) in diagram.cospans().iter().enumerate() {
+            exploded_graph.add_edge(
+                slices[Regular(i).to_int() + 1],
+                slices[Singular(i).to_int() + 1],
+                cospan.forward.convert(),
+            );
+
+            exploded_graph.add_edge(
+                slices[Regular(i + 1).to_int() + 1],
+                slices[Singular(i).to_int() + 1],
+                cospan.backward.convert(),
+            );
+        }
+
+        // Identity rewrite from target slice
+        exploded_graph.add_edge(
+            slices[diagram.size() * 2 + 2],
+            slices[diagram.size() * 2 + 1],
+            GenericRewrite::identity(diagram.dimension() - 1),
+        );
+
+        node_to_slices.push(slices);
+    }
+
+    for ed in graph.edges_values() {
+        let rewrite: &GenericRewriteN<_> = ed.inner().try_into()?;
+
+        let source_slices = &node_to_slices[ed.source()];
+        let source_size = source_slices.len();
+        let target_slices = &node_to_slices[ed.target()];
+        let target_size = target_slices.len();
+
+        // Identity rewrite between source slices
+        exploded_graph.add_edge(
+            source_slices[0],
+            target_slices[0],
+            GenericRewrite::identity(rewrite.dimension() - 1),
+        );
+
+        // Identity rewrite between target slices
+        exploded_graph.add_edge(
+            source_slices[source_size - 1],
+            target_slices[target_size - 1],
+            GenericRewrite::identity(rewrite.dimension() - 1),
+        );
+
+        // Singular slices
+        for source_height in 0..(source_size - 3) / 2 {
+            let target_height = rewrite.singular_image(source_height);
+            exploded_graph.add_edge(
+                source_slices[Singular(source_height).to_int() + 1],
+                target_slices[Singular(target_height).to_int() + 1],
+                rewrite.slice(source_height),
+            );
+        }
+
+        // Regular slices
+        for target_height in 0..(target_size - 1) / 2 {
+            let source_height = rewrite.regular_image(target_height);
+            exploded_graph.add_edge(
+                source_slices[Regular(source_height).to_int() + 1],
+                target_slices[Regular(target_height).to_int() + 1],
+                GenericRewrite::identity(rewrite.dimension() - 1),
+            );
+        }
+    }
+
+    Ok(exploded_graph)
 }
 
 pub struct TopologicalSort(Vec<Node>);

--- a/homotopy-core/src/projection.rs
+++ b/homotopy-core/src/projection.rs
@@ -77,14 +77,7 @@ pub struct Depths {
 
 impl Depths {
     pub fn new(diagram: &DiagramN) -> Result<Self, DimensionError> {
-        if diagram.dimension() < 2 {
-            return Err(DimensionError);
-        }
-
-        let graph = GraphBuilder::new(diagram.clone().into())
-            .explode()?
-            .explode()?
-            .build();
+        let graph = GraphBuilder::build(diagram.clone().into(), 2)?;
 
         let mut node_depths = IdxVec::splat(None, graph.node_count());
         let mut edge_depths = IdxVec::splat(None, graph.edge_count());

--- a/homotopy-core/src/projection.rs
+++ b/homotopy-core/src/projection.rs
@@ -10,18 +10,17 @@ use std::{
     convert::{Into, TryFrom},
 };
 
-use petgraph::{
-    graph::{DiGraph, NodeIndex},
-    visit::{EdgeRef, IntoNodeReferences, Topo, Walker},
-    EdgeDirection,
+use homotopy_common::{
+    graph::{Edge, Node},
+    idx::IdxVec,
 };
 use serde::Serialize;
 
 use crate::{
-    common::{Boundary, Generator, SliceIndex},
+    common::{Boundary, DimensionError, Generator, SliceIndex},
     diagram::DiagramN,
-    graph::GraphBuilder,
-    Diagram, Rewrite,
+    graph::{GraphBuilder, SliceGraph, TopologicalSort},
+    Rewrite,
 };
 
 /// Diagram analysis that determines the generator displayed at any point in the 2-dimensional
@@ -70,65 +69,67 @@ impl Generators {
 /// Diagram analysis that finds the depth of cells in the 2-dimensional projection of a diagram.
 #[derive(Debug, Clone)]
 pub struct Depths {
-    graph: DiGraph<([SliceIndex; 2], Diagram), Rewrite>,
-    coord_to_node: HashMap<[SliceIndex; 2], NodeIndex<u32>>,
-    edge_depths: Vec<Option<usize>>,
-    node_depths: Vec<Option<usize>>,
+    graph: SliceGraph,
+    node_depths: IdxVec<Node, Option<usize>>,
+    edge_depths: IdxVec<Edge, Option<usize>>,
+    coord_to_node: HashMap<[SliceIndex; 2], Node>,
 }
 
 impl Depths {
-    pub fn new(diagram: &DiagramN) -> Self {
+    pub fn new(diagram: &DiagramN) -> Result<Self, DimensionError> {
         if diagram.dimension() < 2 {
-            panic!();
+            return Err(DimensionError);
         }
 
-        let graph = GraphBuilder::new((), diagram.clone().into())
-            .explode(|y, ()| y)
-            .unwrap()
-            .explode(|x, y| [y, x])
-            .unwrap()
+        let graph = GraphBuilder::new(diagram.clone().into())
+            .explode()?
+            .explode()?
             .build();
 
-        let coord_to_node = graph.node_references().map(|n| (n.1 .0, n.0)).collect();
+        let mut node_depths = IdxVec::splat(None, graph.node_count());
+        let mut edge_depths = IdxVec::splat(None, graph.edge_count());
 
-        let mut edge_depths: Vec<Option<usize>> = [None].repeat(graph.edge_count());
-        let mut node_depths: Vec<Option<usize>> = [None].repeat(graph.node_count());
-
-        for node in Topo::new(&graph).iter(&graph) {
-            let mut node_depth = None;
-
-            for edge in graph.edges_directed(node, EdgeDirection::Incoming) {
-                if let Rewrite::RewriteN(r) = edge.weight() {
-                    let edge_depth =
-                        node_depths[edge.source().index()].map(|d| r.singular_image(d));
-                    edge_depths[edge.id().index()] = edge_depth;
+        for node in TopologicalSort::new(&graph) {
+            for edge in graph.incoming_edges(node) {
+                if let Rewrite::RewriteN(r) = &graph[edge] {
+                    edge_depths[edge] =
+                        node_depths[graph.source(edge)].map(|d| r.singular_image(d));
 
                     let target_depth = r.targets().first().copied();
-                    node_depth = min_defined(min_defined(node_depth, edge_depth), target_depth);
-                };
+                    node_depths[node] = min_defined(
+                        target_depth,
+                        min_defined(node_depths[node], edge_depths[edge]),
+                    );
+                }
             }
-
-            node_depths[node.index()] = node_depth;
         }
 
-        Self {
+        let coord_to_node = graph
+            .nodes()
+            .map(|(n, nd)| ([nd.0[0], nd.0[1]], n))
+            .collect();
+
+        Ok(Self {
             graph,
-            coord_to_node,
-            edge_depths,
             node_depths,
-        }
+            edge_depths,
+            coord_to_node,
+        })
     }
 
     pub fn node_depth(&self, coord: [SliceIndex; 2]) -> Option<usize> {
-        let node = *self.coord_to_node.get(&coord)?;
-        self.node_depths[node.index()]
+        let &n = self.coord_to_node.get(&coord)?;
+        self.node_depths[n]
     }
 
     pub fn edge_depth(&self, from: [SliceIndex; 2], to: [SliceIndex; 2]) -> Option<usize> {
-        let from = *self.coord_to_node.get(&from)?;
-        let to = *self.coord_to_node.get(&to)?;
-        let edge = self.graph.edges_connecting(from, to).next()?;
-        self.edge_depths[edge.id().index()]
+        let &from = self.coord_to_node.get(&from)?;
+        let &to = self.coord_to_node.get(&to)?;
+        let e = self
+            .graph
+            .outgoing_edges(from)
+            .find(|&e| self.graph.target(e) == to)?;
+        self.edge_depths[e]
     }
 
     pub fn edges_above(&self, depth: usize, to: [SliceIndex; 2]) -> Vec<[SliceIndex; 2]> {
@@ -138,9 +139,12 @@ impl Depths {
         };
 
         self.graph
-            .edges_directed(to, EdgeDirection::Incoming)
-            .filter_map(|e| match self.edge_depths[e.id().index()] {
-                Some(d) if d < depth => self.graph.node_weight(e.source()).map(|e| e.0),
+            .incoming_edges(to)
+            .filter_map(|e| match self.edge_depths[e] {
+                Some(d) if d < depth => self
+                    .graph
+                    .node_weight(self.graph.source(e))
+                    .map(|(coord, _)| [coord[0], coord[1]]),
                 _ => None,
             })
             .collect()

--- a/homotopy-core/src/rewrite.rs
+++ b/homotopy-core/src/rewrite.rs
@@ -1141,6 +1141,70 @@ pub enum MalformedRewrite {
     NotCommutativeMiddle(usize, usize),
 }
 
+impl<A, T> GenericCone<A>
+where
+    A: RewriteAllocator<Payload = T>,
+    T: Default,
+{
+    pub fn convert<B, U>(&self) -> GenericCone<B>
+    where
+        B: RewriteAllocator<Payload = U>,
+        U: Default,
+    {
+        GenericCone::new(
+            self.index,
+            self.internal
+                .source
+                .iter()
+                .map(GenericCospan::convert)
+                .collect(),
+            self.internal.target.convert(),
+            self.internal
+                .slices
+                .iter()
+                .map(GenericRewrite::convert)
+                .collect(),
+        )
+    }
+}
+
+impl<A, T> GenericCospan<A>
+where
+    A: RewriteAllocator<Payload = T>,
+    T: Default,
+{
+    pub fn convert<B, U>(&self) -> GenericCospan<B>
+    where
+        B: RewriteAllocator<Payload = U>,
+        U: Default,
+    {
+        GenericCospan {
+            forward: self.forward.convert(),
+            backward: self.backward.convert(),
+        }
+    }
+}
+
+impl<A, T> GenericRewrite<A>
+where
+    A: RewriteAllocator<Payload = T>,
+    T: Default,
+{
+    pub fn convert<B, U>(&self) -> GenericRewrite<B>
+    where
+        B: RewriteAllocator<Payload = U>,
+        U: Default,
+    {
+        match self {
+            Self::Rewrite0(r) => GenericRewrite::Rewrite0(*r),
+            Self::RewriteN(r) => GenericRewrite::RewriteN(GenericRewriteN::new_unsafe(
+                r.dimension(),
+                r.cones().iter().map(GenericCone::convert).collect(),
+            )),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/homotopy-graphics/src/clay/geom.rs
+++ b/homotopy-graphics/src/clay/geom.rs
@@ -397,7 +397,7 @@ impl Mesh {
 
         // ELEMENTS: 0-CUBES
         let mut elements_0d: IdxVec<Node, Element> = IdxVec::new();
-        for n in graph.inner().nodes_keys() {
+        for n in graph.inner().node_keys() {
             let vertex = vertices[graph.label(n)];
             elements_0d.push(mesh.mk_element_0(vertex));
         }

--- a/homotopy-web/src/app/diagram_svg.rs
+++ b/homotopy-web/src/app/diagram_svg.rs
@@ -107,7 +107,7 @@ impl PreparedDiagram {
         let generators = Generators::new(diagram);
         let layout = Layout::new(diagram, 2000).unwrap();
         let complex = make_complex(diagram);
-        let depths = Depths::new(diagram);
+        let depths = Depths::new(diagram).unwrap();
         let graphic = GraphicElement::build(&complex, &layout, &generators, &depths);
         let actions = ActionRegion::build(&complex, &layout);
 
@@ -130,8 +130,6 @@ impl PreparedDiagram {
                 ((&action).into(), shape)
             })
             .collect();
-
-        let depths = Depths::new(diagram);
 
         Self {
             graphic,


### PR DESCRIPTION
`GraphBuilder` is now generic in the `RewriteAllocator` so it can also explode cubical graphs in cubicalisation.

I also simplified the keys since they are always coordinates.