### PR TITLE
Add memoization to deserialization to prevent callstack from exploding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bimap"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ae17cabbc8a38a1e3e4c1a6a664e9a09672dc14d0896fa8d865d3a5a446b07"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +635,7 @@ name = "homotopy-core"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "bimap",
  "cargo-husky",
  "criterion",
  "hashconsing",

--- a/homotopy-core/Cargo.toml
+++ b/homotopy-core/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 homotopy-common = { path = "../homotopy-common" }
+bimap = "0.6.1"
 hashconsing = "1.5.0"
 highway = "0.6.4"
 rustc-hash = "1.1.0"

--- a/homotopy-core/tests/serialize.rs
+++ b/homotopy-core/tests/serialize.rs
@@ -15,7 +15,7 @@ fn serialize_associator() {
     assert_debug_snapshot!(base64::encode(&serialized));
 
     let deserialized = {
-        let store: Store = rmp_serde::decode::from_slice(&serialized).unwrap();
+        let mut store: Store = rmp_serde::decode::from_slice(&serialized).unwrap();
         store.unpack_diagram(key).unwrap()
     };
 

--- a/homotopy-web/src/model/serialize.rs
+++ b/homotopy-web/src/model/serialize.rs
@@ -177,7 +177,7 @@ pub fn deserialize(data: &[u8]) -> Option<(Signature, Option<Workspace>)> {
     }?;
     // Migrate to current version
     let data: Data = data.into();
-    let store = data.store;
+    let mut store = data.store;
 
     let signature = data
         .signature


### PR DESCRIPTION
The 6-associator now takes < 100ms to import