### PR TITLE
Preserve orbit state when changing slices

### DIFF
--- a/homotopy-web/src/app.rs
+++ b/homotopy-web/src/app.rs
@@ -15,6 +15,8 @@ use crate::{
     model,
 };
 
+use self::diagram_gl::OrbitControl;
+
 mod attach;
 mod diagram_gl;
 mod diagram_svg;
@@ -35,6 +37,7 @@ pub enum Message {
 pub struct App {
     state: model::State,
     panzoom: PanZoom,
+    orbit_control: OrbitControl,
     signature_stylesheet: SignatureStylesheet,
     toaster: Toaster,
     _settings: AppSettings,
@@ -56,6 +59,7 @@ impl Component for App {
         let mut app = Self {
             state,
             panzoom: PanZoom::new(),
+            orbit_control: OrbitControl::new(),
             signature_stylesheet,
             toaster: Toaster::new(),
             _settings: AppSettings::connect(Callback::noop()),
@@ -72,6 +76,7 @@ impl Component for App {
                 if let model::Action::Proof(ref action) = action {
                     if self.state.with_proof(|p| p.resets_panzoom(action)) {
                         self.panzoom.reset();
+                        self.orbit_control.reset();
                     }
                 }
 

--- a/homotopy-web/src/app/workspace/view_control.rs
+++ b/homotopy-web/src/app/workspace/view_control.rs
@@ -1,12 +1,13 @@
 use yew::prelude::*;
 
 use crate::{
-    app::{Icon, IconSize},
+    app::{diagram_gl::OrbitControl, Icon, IconSize},
     components::panzoom::PanZoom,
 };
 
 pub struct ViewControl {
     panzoom: PanZoom,
+    orbit_control: OrbitControl,
 }
 
 pub enum ViewMessage {
@@ -22,14 +23,24 @@ impl Component for ViewControl {
     fn create(_ctx: &Context<Self>) -> Self {
         Self {
             panzoom: PanZoom::new(),
+            orbit_control: OrbitControl::new(),
         }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
-            ViewMessage::ZoomIn => self.panzoom.zoom_in(),
-            ViewMessage::ZoomOut => self.panzoom.zoom_out(),
-            ViewMessage::Reset => self.panzoom.reset(),
+            ViewMessage::ZoomIn => {
+                self.panzoom.zoom_in();
+                self.orbit_control.zoom_in();
+            },
+            ViewMessage::ZoomOut => {
+                self.panzoom.zoom_out();
+                self.orbit_control.zoom_out();
+            }
+            ViewMessage::Reset => {
+                self.panzoom.reset();
+                self.orbit_control.reset();
+            }
         }
         false
     }

--- a/homotopy-web/src/components.rs
+++ b/homotopy-web/src/components.rs
@@ -11,3 +11,4 @@ pub mod panzoom;
 pub mod rawhtml;
 pub mod settings;
 pub mod toast;
+pub mod touch_interface;

--- a/homotopy-web/src/components/panzoom.rs
+++ b/homotopy-web/src/components/panzoom.rs
@@ -144,8 +144,11 @@ impl Component for PanZoomComponent {
 
         let on_mouse_move = PanZoomState::on_mouse_move();
         let on_mouse_up = PanZoomState::on_mouse_up();
-        let on_mouse_down = PanZoomState::on_mouse_down();
-
+        let on_mouse_down = Callback::from(move |e: MouseEvent| {
+            if e.alt_key() {
+                PanZoomState::on_mouse_down().emit(e);
+            }
+        });
         let on_wheel = {
             let on_scroll = ctx.props().on_scroll.clone();
             let node_ref = self.node_ref.clone();
@@ -159,7 +162,6 @@ impl Component for PanZoomComponent {
                 }
             })
         };
-
         let on_touch_move = PanZoomState::on_touch_move(&self.node_ref);
         let on_touch_update = PanZoomState::on_touch_update(&self.node_ref);
 

--- a/homotopy-web/src/components/panzoom.rs
+++ b/homotopy-web/src/components/panzoom.rs
@@ -1,23 +1,11 @@
-use closure::closure;
 use homotopy_core::Direction;
 use yew::prelude::*;
 
-use super::delta::DeltaAgent;
 use crate::components::{
-    delta::{Delta, DeltaCallback, State},
-    node_midpoint, read_touch_list, Finger, Point, Vector,
+    delta::{Delta, DeltaAgent, DeltaCallback},
+    touch_interface::{TouchAction, TouchInterface},
+    Finger, Point, Vector,
 };
-
-#[derive(Debug, Clone)]
-pub enum PanZoomAction {
-    TouchUpdate(Vec<(Finger, Point)>),
-    TouchMove(Vec<(Finger, Point)>),
-    MouseWheel(Point, f64),
-    MouseDown(Point),
-    MouseMove(Point),
-    MouseUp,
-    Reset,
-}
 
 pub struct PanZoomState {
     pub translate: Vector,
@@ -37,58 +25,60 @@ impl Default for PanZoomState {
     }
 }
 
-impl State for PanZoomState {
-    type Action = PanZoomAction;
+impl TouchInterface for PanZoomState {
+    fn mouse_down(&mut self, point: Point) {
+        self.mouse = Some(point);
+    }
 
-    fn update(&mut self, action: &Self::Action) {
-        match *action {
-            PanZoomAction::MouseDown(point) => self.mouse = Some(point),
-            PanZoomAction::MouseUp => self.mouse = None,
-            PanZoomAction::MouseMove(next) => {
-                if let Some(prev) = self.mouse {
-                    self.translate += next - prev;
-                    self.mouse = Some(next);
-                }
-            }
-            PanZoomAction::MouseWheel(point, delta) => {
-                let scale = self.scale * if delta < 0.0 { 1.1 } else { 1.0 / 1.1 };
-                self.translate = point - (point - self.translate) * (scale / self.scale);
-                self.scale = scale;
-            }
-            PanZoomAction::TouchMove(ref touches) => {
-                let mut touches = touches.clone();
-                touches.sort_by_key(|(finger, _)| *finger);
+    fn mouse_up(&mut self) {
+        self.mouse = None;
+    }
 
-                if touches.len() != 2 || self.touches.len() != 2 {
-                    self.touches = touches;
-                    return;
-                }
-
-                let average_next = (touches[0].1.to_vector() + touches[1].1.to_vector()) * 0.5;
-                let average_prev =
-                    (self.touches[0].1.to_vector() + self.touches[1].1.to_vector()) * 0.5;
-
-                let scale = {
-                    let distance_prev = (self.touches[0].1 - self.touches[1].1).length().max(0.01);
-                    let distance_next = (touches[0].1 - touches[1].1).length().max(0.01);
-                    self.scale * (distance_next / distance_prev)
-                };
-
-                self.translate =
-                    average_next - (average_prev - self.translate) * (scale / self.scale);
-                self.scale = scale;
-                self.touches = touches;
-            }
-            PanZoomAction::TouchUpdate(ref touches) => {
-                let mut touches = touches.clone();
-                touches.sort_by_key(|(finger, _)| *finger);
-                self.touches = touches;
-            }
-            PanZoomAction::Reset => {
-                self.translate = Default::default();
-                self.scale = 1.0;
-            }
+    fn mouse_move(&mut self, next: Point) {
+        if let Some(prev) = self.mouse {
+            self.translate += next - prev;
+            self.mouse = Some(next);
         }
+    }
+
+    fn mouse_wheel(&mut self, point: Point, delta: f64) {
+        let scale = self.scale * if delta < 0.0 { 1.1 } else { 1.0 / 1.1 };
+        self.translate = point - (point - self.translate) * (scale / self.scale);
+        self.scale = scale;
+    }
+
+    fn touch_move(&mut self, touches: &[(Finger, Point)]) {
+        let mut touches = touches.to_vec();
+        touches.sort_by_key(|(finger, _)| *finger);
+
+        if touches.len() != 2 || self.touches.len() != 2 {
+            self.touches = touches;
+            return;
+        }
+
+        let average_next = (touches[0].1.to_vector() + touches[1].1.to_vector()) * 0.5;
+        let average_prev = (self.touches[0].1.to_vector() + self.touches[1].1.to_vector()) * 0.5;
+
+        let scale = {
+            let distance_prev = (self.touches[0].1 - self.touches[1].1).length().max(0.01);
+            let distance_next = (touches[0].1 - touches[1].1).length().max(0.01);
+            self.scale * (distance_next / distance_prev)
+        };
+
+        self.translate = average_next - (average_prev - self.translate) * (scale / self.scale);
+        self.scale = scale;
+        self.touches = touches;
+    }
+
+    fn touch_update(&mut self, touches: &[(Finger, Point)]) {
+        let mut touches = touches.to_vec();
+        touches.sort_by_key(|(finger, _)| *finger);
+        self.touches = touches;
+    }
+
+    fn reset(&mut self) {
+        self.translate = Default::default();
+        self.scale = 1.0;
     }
 }
 
@@ -135,7 +125,7 @@ impl Component for PanZoomComponent {
     fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         let PanZoomMessage::Delta(translate, scale) = msg;
 
-        if self.translate == translate || self.scale == scale {
+        if self.translate == translate && self.scale == scale {
             return false;
         }
 
@@ -152,56 +142,17 @@ impl Component for PanZoomComponent {
             s = self.scale
         );
 
-        let on_mouse_move = {
-            let delta = Delta::<PanZoomState>::new();
-            Callback::from(closure!(|e: MouseEvent| {
-                e.prevent_default();
-                delta.emit(PanZoomAction::MouseMove(
-                    (f64::from(e.client_x()), f64::from(e.client_y())).into(),
-                ));
-            }))
-        };
-
-        let on_mouse_up = {
-            let delta = Delta::<PanZoomState>::new();
-            Callback::from(closure!(|e: MouseEvent| {
-                e.prevent_default();
-                delta.emit(PanZoomAction::MouseUp);
-            }))
-        };
-
-        let on_mouse_down = {
-            let delta = Delta::<PanZoomState>::new();
-            Callback::from(closure!(|e: MouseEvent| {
-                e.prevent_default();
-                if e.alt_key() {
-                    delta.emit(PanZoomAction::MouseDown(
-                        (f64::from(e.client_x()), f64::from(e.client_y())).into(),
-                    ));
-                }
-            }))
-        };
+        let on_mouse_move = PanZoomState::on_mouse_move();
+        let on_mouse_up = PanZoomState::on_mouse_up();
+        let on_mouse_down = PanZoomState::on_mouse_down();
 
         let on_wheel = {
-            let delta = Delta::<PanZoomState>::new();
-            let node_ref = self.node_ref.clone();
             let on_scroll = ctx.props().on_scroll.clone();
-
+            let node_ref = self.node_ref.clone();
             Callback::from(move |e: WheelEvent| {
-                let dy = e.delta_y();
                 if e.alt_key() {
-                    e.prevent_default();
-
-                    let midpoint = node_midpoint(&node_ref).unwrap();
-
-                    // Offset the observed x and y by half the dimensinos of the panzoom view to
-                    // account for centering (not required on mouse moves as that information is
-                    // only used relatively)
-                    let x = f64::from(e.client_x()) - midpoint.x;
-                    let y = f64::from(e.client_y()) - midpoint.y;
-
-                    delta.emit(PanZoomAction::MouseWheel((x, y).into(), dy));
-                } else if dy > 0.0 {
+                    PanZoomState::on_wheel(&node_ref).emit(e);
+                } else if e.delta_y() > 0.0 {
                     on_scroll.emit(Direction::Forward);
                 } else {
                     on_scroll.emit(Direction::Backward);
@@ -209,32 +160,8 @@ impl Component for PanZoomComponent {
             })
         };
 
-        let on_touch_move = {
-            let delta = Delta::<PanZoomState>::new();
-            let node_ref = self.node_ref.clone();
-            Callback::from(closure!(|e: TouchEvent| {
-                e.prevent_default();
-                let midpoint = node_midpoint(&node_ref).unwrap();
-                delta.emit(PanZoomAction::TouchMove(
-                    read_touch_list(&e.touches())
-                        .map(|(finger, point)| (finger, (point - midpoint).to_point()))
-                        .collect(),
-                ));
-            }))
-        };
-
-        let on_touch_update = {
-            let delta = Delta::<PanZoomState>::new();
-            let node_ref = self.node_ref.clone();
-            Callback::from(closure!(|e: TouchEvent| {
-                let midpoint = node_midpoint(&node_ref).unwrap();
-                delta.emit(PanZoomAction::TouchUpdate(
-                    read_touch_list(&e.touches())
-                        .map(|(finger, point)| (finger, (point - midpoint).to_point()))
-                        .collect(),
-                ));
-            }))
-        };
+        let on_touch_move = PanZoomState::on_touch_move(&self.node_ref);
+        let on_touch_update = PanZoomState::on_touch_update(&self.node_ref);
 
         html! {
             <content
@@ -271,16 +198,16 @@ impl PanZoom {
 
     pub fn zoom_in(&self) {
         self.0
-            .emit(PanZoomAction::MouseWheel(Default::default(), -20.0));
+            .emit(TouchAction::MouseWheel(Default::default(), -20.0));
     }
 
     pub fn zoom_out(&self) {
         self.0
-            .emit(PanZoomAction::MouseWheel(Default::default(), 20.0));
+            .emit(TouchAction::MouseWheel(Default::default(), 20.0));
     }
 
     pub fn reset(&self) {
-        self.0.emit(PanZoomAction::Reset);
+        self.0.emit(TouchAction::Reset);
     }
 
     pub fn register(&self, callback: DeltaCallback<PanZoomState>) {

--- a/homotopy-web/src/components/touch_interface.rs
+++ b/homotopy-web/src/components/touch_interface.rs
@@ -1,0 +1,128 @@
+use closure::closure;
+use yew::prelude::*;
+
+use crate::components::{
+    delta::{Delta, State},
+    node_midpoint, read_touch_list, Finger, Point,
+};
+
+#[derive(Debug, Clone)]
+pub enum TouchAction {
+    TouchUpdate(Vec<(Finger, Point)>),
+    TouchMove(Vec<(Finger, Point)>),
+    MouseWheel(Point, f64),
+    MouseDown(Point),
+    MouseMove(Point),
+    MouseUp,
+    Reset,
+}
+
+pub trait TouchInterface: Default + 'static {
+    fn mouse_down(&mut self, point: Point);
+
+    fn mouse_up(&mut self);
+
+    fn mouse_move(&mut self, next: Point);
+
+    fn mouse_wheel(&mut self, point: Point, delta: f64);
+
+    fn touch_move(&mut self, touches: &[(Finger, Point)]);
+
+    fn touch_update(&mut self, touches: &[(Finger, Point)]);
+
+    fn reset(&mut self);
+
+    fn on_mouse_move() -> Callback<MouseEvent> {
+        let delta = Delta::<Self>::new();
+        Callback::from(closure!(|e: MouseEvent| {
+            e.prevent_default();
+            delta.emit(TouchAction::MouseMove(
+                (f64::from(e.client_x()), f64::from(e.client_y())).into(),
+            ));
+        }))
+    }
+
+    fn on_mouse_up() -> Callback<MouseEvent> {
+        let delta = Delta::<Self>::new();
+        Callback::from(closure!(|e: MouseEvent| {
+            e.prevent_default();
+            delta.emit(TouchAction::MouseUp);
+        }))
+    }
+
+    fn on_mouse_down() -> Callback<MouseEvent> {
+        let delta = Delta::<Self>::new();
+        Callback::from(closure!(|e: MouseEvent| {
+            e.prevent_default();
+            if e.alt_key() {
+                delta.emit(TouchAction::MouseDown(
+                    (f64::from(e.client_x()), f64::from(e.client_y())).into(),
+                ));
+            }
+        }))
+    }
+
+    fn on_wheel(node_ref: &NodeRef) -> Callback<WheelEvent> {
+        let delta = Delta::<Self>::new();
+        let node_ref = node_ref.clone();
+        Callback::from(move |e: WheelEvent| {
+            e.prevent_default();
+
+            let midpoint = node_midpoint(&node_ref).unwrap();
+
+            // Offset the observed x and y by half the dimensions of the panzoom view to
+            // account for centering (not required on mouse moves as that information is
+            // only used relatively)
+            let x = f64::from(e.client_x()) - midpoint.x;
+            let y = f64::from(e.client_y()) - midpoint.y;
+
+            delta.emit(TouchAction::MouseWheel((x, y).into(), e.delta_y()));
+        })
+    }
+
+    fn on_touch_move(node_ref: &NodeRef) -> Callback<TouchEvent> {
+        let delta = Delta::<Self>::new();
+        let node_ref = node_ref.clone();
+        Callback::from(closure!(|e: TouchEvent| {
+            e.prevent_default();
+            let midpoint = node_midpoint(&node_ref).unwrap();
+            delta.emit(TouchAction::TouchMove(
+                read_touch_list(&e.touches())
+                    .map(|(finger, point)| (finger, (point - midpoint).to_point()))
+                    .collect(),
+            ));
+        }))
+    }
+
+    fn on_touch_update(node_ref: &NodeRef) -> Callback<TouchEvent> {
+        let delta = Delta::<Self>::new();
+        let node_ref = node_ref.clone();
+        Callback::from(closure!(|e: TouchEvent| {
+            let midpoint = node_midpoint(&node_ref).unwrap();
+            delta.emit(TouchAction::TouchUpdate(
+                read_touch_list(&e.touches())
+                    .map(|(finger, point)| (finger, (point - midpoint).to_point()))
+                    .collect(),
+            ));
+        }))
+    }
+}
+
+impl<T> State for T
+where
+    T: TouchInterface,
+{
+    type Action = TouchAction;
+
+    fn update(&mut self, action: &Self::Action) {
+        match action {
+            TouchAction::MouseDown(point) => self.mouse_down(*point),
+            TouchAction::MouseUp => self.mouse_up(),
+            TouchAction::MouseMove(next) => self.mouse_move(*next),
+            TouchAction::MouseWheel(point, delta) => self.mouse_wheel(*point, *delta),
+            TouchAction::TouchMove(touches) => self.touch_move(touches),
+            TouchAction::TouchUpdate(touches) => self.touch_update(touches),
+            TouchAction::Reset => self.reset(),
+        }
+    }
+}

--- a/homotopy-web/src/components/touch_interface.rs
+++ b/homotopy-web/src/components/touch_interface.rs
@@ -53,12 +53,9 @@ pub trait TouchInterface: Default + 'static {
     fn on_mouse_down() -> Callback<MouseEvent> {
         let delta = Delta::<Self>::new();
         Callback::from(closure!(|e: MouseEvent| {
-            e.prevent_default();
-            if e.alt_key() {
-                delta.emit(TouchAction::MouseDown(
-                    (f64::from(e.client_x()), f64::from(e.client_y())).into(),
-                ));
-            }
+            delta.emit(TouchAction::MouseDown(
+                (f64::from(e.client_x()), f64::from(e.client_y())).into(),
+            ));
         }))
     }
 

--- a/homotopy-web/src/model/proof.rs
+++ b/homotopy-web/src/model/proof.rs
@@ -242,7 +242,7 @@ impl ProofState {
             }
             Action::SelectGenerator(_) => self.workspace.is_none(),
             Action::AscendSlice(i) => i > 0,
-            Action::ClearWorkspace | Action::DescendSlice(_) => true,
+            Action::ClearWorkspace | Action::DescendSlice(_) | Action::UpdateView(_) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
Fixes #282 

Also refactors a lot of the panzoom code and therefore incidentally fixes #329 (there was an `||` that should have bene an `&&`).