### PR TITLE
SVG export, closes #196

### DIFF
--- a/homotopy-web/src/app/sidebar/buttons.rs
+++ b/homotopy-web/src/app/sidebar/buttons.rs
@@ -115,4 +115,10 @@ declare_sidebar_tools! {
         "download",
         model::Action::ExportTikz,
     }
+
+    BUTTON_SVG {
+        "Export to SVG",
+        "download",
+        model::Action::ExportSvg,
+    }
 }

--- a/homotopy-web/src/app/signature_stylesheet.rs
+++ b/homotopy-web/src/app/signature_stylesheet.rs
@@ -21,9 +21,11 @@ pub struct SignatureStylesheet {
 
 impl SignatureStylesheet {
     pub fn new(prefix: impl Into<String>) -> Self {
+        let element = document().create_element("style").unwrap();
+        element.set_id("signature__stylesheet");
         Self {
             signature: Default::default(),
-            element: document().create_element("style").unwrap(),
+            element,
             prefix: prefix.into(),
         }
     }

--- a/homotopy-web/src/components/panzoom.rs
+++ b/homotopy-web/src/components/panzoom.rs
@@ -177,6 +177,7 @@ impl Component for PanZoomComponent {
                 ref={self.node_ref.clone()}
             >
                 <div
+                    id="panzoom__inner__0"
                     class="panzoom__inner"
                     style={style}
                 >


### PR DESCRIPTION
Implemented by pulling the SVG directly from the DOM, as we already render it.

This is a slightly non-trivial business as we need both the generated SVG and its stylesheets, which are handled by completely different code paths.

As documented in homotopy-web/src/model.rs, we add IDs to both the panzoom component containing the SVG and the stylesheet created by SignatureStylesheet, to the use DOM APIs to request the inner_html.

I'm not thrilled about the amount of code this adds to homotopy-web/src/model.rs (although most of it is documentations), and we definitely need a different icon for exporting TiKz and SVG.