### PR TITLE
Manim export for 2d diagrams

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,7 @@
             ++ (with self.pkgs; [
               (lib.hiPrio rust-bin.nightly.latest.rustfmt)
               (rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
+              coreutils
             ]);
           commands =
             super.commands

--- a/homotopy-graphics/src/lib.rs
+++ b/homotopy-graphics/src/lib.rs
@@ -45,6 +45,7 @@
 pub mod buffers;
 pub mod geom;
 pub mod gl;
+pub mod manim;
 pub mod parity;
 pub mod subdivision;
 pub mod svg;

--- a/homotopy-graphics/src/manim.rs
+++ b/homotopy-graphics/src/manim.rs
@@ -1,0 +1,284 @@
+use std::fmt::Write;
+
+use euclid::{default::Point2D, Vector2D};
+use homotopy_common::hash::FastHashMap;
+use homotopy_core::{
+    common::DimensionError,
+    complex::make_complex,
+    layout::Layout,
+    projection::{Depths, Projection},
+    Diagram, Generator,
+};
+use itertools::Itertools;
+use lyon_geom::{CubicBezierSegment, Line, LineSegment};
+use lyon_path::{Event, Path};
+
+use crate::svg::render::GraphicElement;
+
+const OCCLUSION_DELTA: f32 = 0.2;
+const INDENT: &str = "    ";
+
+pub fn color(generator: Generator) -> String {
+    format!("generator_{}_{}", generator.id, generator.dimension)
+}
+
+pub fn render(diagram: &Diagram, stylesheet: &str) -> Result<String, DimensionError> {
+    let layout = Layout::<2>::new(diagram)?;
+    let complex = make_complex(diagram);
+    let depths = Depths::<2>::new(diagram)?;
+    let projection = Projection::<2>::new(diagram, &layout, &depths)?;
+    let graphic = GraphicElement::build(&complex, &layout, &projection, &depths);
+
+    let mut surfaces = Vec::default();
+    let mut wires: FastHashMap<usize, Vec<(Generator, Path)>> = FastHashMap::default();
+    let mut points = Vec::default();
+    for element in graphic {
+        match element {
+            GraphicElement::Surface(g, path) => surfaces.push((g, path)),
+            GraphicElement::Wire(g, path, mask) => {
+                wires.entry(mask.len()).or_default().push((g, path));
+            }
+            GraphicElement::Point(g, point) => points.push((g, point)),
+        }
+    }
+
+    let mut manim = String::new();
+    writeln!(manim, "# Uncomment line below\n#from manim import *\n").unwrap();
+    manim.push_str(stylesheet);
+
+    writeln!(
+        manim,
+        "\n# Our main class\nclass HomotopyIoManim(Scene):\n{ind}def construct(self):",
+        ind = INDENT
+    )
+    .unwrap();
+
+    // Surfaces
+    writeln!(manim, "{ind}{ind}# Surfaces", ind = INDENT).unwrap();
+    for (g, path) in surfaces {
+        write!(
+            manim,
+            "{ind}{ind}path_{id}_{dim} = VMobject().set_fill({color}, 1.0){path}\n{ind}{ind}self.play(Create(path_{id}_{dim}))\n{ind}{ind}self.wait(1)\n",
+            ind=INDENT,
+            color=color(g),
+            id=g.id,
+            dim=g.dimension,
+            path=&render_path(&path)
+        )
+        .unwrap();
+    }
+
+    // Wires
+    for (i, (_, layer)) in wires
+        .into_iter()
+        .sorted_by_cached_key(|(k, _)| *k)
+        .rev()
+        .enumerate()
+    {
+        // Background
+        if i > 0 {
+            writeln!(manim, "\\begin{{scope}}").unwrap();
+            write!(manim, "\\clip ").unwrap();
+            for (_, path) in &layer {
+                let left = offset(-OCCLUSION_DELTA, path).reversed();
+                let right = offset(OCCLUSION_DELTA, path);
+                manim.push_str(&render_path(&right));
+                manim.push_str(" -- ");
+                manim.push_str(&render_path(&left));
+                manim.push_str(" -- cycle");
+            }
+            writeln!(manim, ";").unwrap();
+            writeln!(manim, "\\Background").unwrap();
+            writeln!(manim, "\\end{{scope}}").unwrap();
+        }
+
+        for (g, path) in &layer {
+            write!(manim, "\\draw[{}!80, line width=5pt] ", color(*g)).unwrap();
+            manim.push_str(&render_path(path));
+            writeln!(manim, ";").unwrap();
+        }
+    }
+
+    // Points
+    for (g, point) in points {
+        write!(manim, "\\fill[{}] ", color(g)).unwrap();
+        manim.push_str(&render_point(point));
+        writeln!(manim, " circle (4pt);").unwrap();
+    }
+
+    writeln!(manim, "\\end{{tikzpicture}}").unwrap();
+
+    Ok(manim)
+}
+
+fn render_point(point: Point2D<f32>) -> String {
+    let x = (point.x * 100.0).round() / 100.0;
+    let y = (point.y * 100.0).round() / 100.0;
+    format!("[{},{},0]", x, y)
+}
+
+fn render_path(path: &Path) -> String {
+    let mut result = String::new();
+    for event in path {
+        match event {
+            Event::Begin { at } => write!(
+                result,
+                ".set_points_as_corners([np.array({pt}),np.array({pt})])",
+                pt = render_point(at)
+            )
+            .unwrap(),
+            Event::Line { to, .. } => write!(
+                result,
+                ".add_line_to(np.array({pt}))",
+                pt = render_point(to)
+            )
+            .unwrap(),
+            Event::Quadratic { ctrl, to, .. } => write!(
+                result,
+                " .. controls {} .. {}",
+                render_point(ctrl),
+                render_point(to)
+            )
+            .unwrap(),
+            Event::Cubic {
+                ctrl1, ctrl2, to, ..
+            } => write!(
+                result,
+                ".add_cubic_bezier_curve_to(np.array({}),np.array({}),np.array({}))",
+                render_point(ctrl1),
+                render_point(ctrl2),
+                render_point(to),
+            )
+            .unwrap(),
+            Event::End { close, .. } => {
+                if close {
+                    //write!(result, " -- cycle").unwrap();
+                }
+            }
+        }
+    }
+    result
+}
+
+// Offsetting a curve.
+// TOOD(@calintat): Move somewhere else.
+fn offset(delta: f32, path: &Path) -> Path {
+    let mut builder = Path::builder();
+
+    for event in path {
+        match event {
+            Event::Cubic {
+                from,
+                ctrl1,
+                ctrl2,
+                to,
+            } => {
+                let segment = offset_cubical(
+                    delta,
+                    CubicBezierSegment {
+                        from,
+                        ctrl1,
+                        ctrl2,
+                        to,
+                    },
+                );
+                builder.begin(segment.from);
+                builder.cubic_bezier_to(segment.ctrl1, segment.ctrl2, segment.to);
+                builder.end(false);
+                return builder.build();
+            }
+            Event::Line { from, to } => {
+                let segment = offset_linear(delta, LineSegment { from, to });
+                builder.begin(segment.from);
+                builder.line_to(segment.to);
+                builder.end(false);
+                return builder.build();
+            }
+            _ => (),
+        }
+    }
+
+    panic!("Cannot offset a path made of multiple segments")
+}
+
+fn perp<U>(v: Vector2D<f32, U>) -> Vector2D<f32, U> {
+    Vector2D::new(v.y, -v.x).normalize()
+}
+
+fn offset_linear(delta: f32, segment: LineSegment<f32>) -> LineSegment<f32> {
+    let v = perp(segment.to - segment.from);
+    LineSegment {
+        from: segment.from + v * delta,
+        to: segment.to + v * delta,
+    }
+}
+
+fn offset_cubical(delta: f32, segment: CubicBezierSegment<f32>) -> CubicBezierSegment<f32> {
+    if segment.from == segment.ctrl1
+        || segment.ctrl1 == segment.ctrl2
+        || segment.ctrl2 == segment.to
+    {
+        let leg = offset_linear(
+            delta,
+            LineSegment {
+                from: segment.from,
+                to: segment.to,
+            },
+        );
+        CubicBezierSegment {
+            from: leg.from,
+            ctrl1: leg.from,
+            ctrl2: leg.to,
+            to: leg.to,
+        }
+    } else {
+        let leg1 = offset_linear(
+            delta,
+            LineSegment {
+                from: segment.from,
+                to: segment.ctrl1,
+            },
+        );
+        let leg2 = offset_linear(
+            delta,
+            LineSegment {
+                from: segment.ctrl1,
+                to: segment.ctrl2,
+            },
+        );
+        let leg3 = offset_linear(
+            delta,
+            LineSegment {
+                from: segment.ctrl2,
+                to: segment.to,
+            },
+        );
+
+        let from = leg1.from;
+
+        let line1 = Line {
+            point: leg1.from,
+            vector: leg1.to - leg1.from,
+        };
+        let line2 = Line {
+            point: leg2.from,
+            vector: leg2.to - leg2.from,
+        };
+        let line3 = Line {
+            point: leg3.from,
+            vector: leg3.to - leg3.from,
+        };
+
+        let ctrl1 = line1.intersection(&line2).unwrap_or(leg1.to);
+        let ctrl2 = line2.intersection(&line3).unwrap_or(leg2.to);
+
+        let to = leg3.to;
+
+        CubicBezierSegment {
+            from,
+            ctrl1,
+            ctrl2,
+            to,
+        }
+    }
+}

--- a/homotopy-graphics/src/manim.rs
+++ b/homotopy-graphics/src/manim.rs
@@ -56,9 +56,9 @@ pub fn render(diagram: &Diagram, stylesheet: &str) -> Result<String, DimensionEr
     // Surfaces
     writeln!(manim, "{ind}{ind}# Surfaces", ind = INDENT).unwrap();
     for (g, path) in surfaces {
-        write!(
+        writeln!(
             manim,
-            "{ind}{ind}path_{id}_{dim} = VMobject().set_fill({color}, 1.0){path}\n{ind}{ind}self.play(Create(path_{id}_{dim}))\n{ind}{ind}self.wait(1)\n",
+            "{ind}{ind}path_{id}_{dim} = VMobject(stroke_width=2).set_fill({color}, 1.0){path}\n{ind}{ind}self.play(Create(path_{id}_{dim}))\n{ind}{ind}self.wait(1)",
             ind=INDENT,
             color=color(g),
             id=g.id,
@@ -77,8 +77,7 @@ pub fn render(diagram: &Diagram, stylesheet: &str) -> Result<String, DimensionEr
     {
         // Background
         if i > 0 {
-            writeln!(manim, "\\begin{{scope}}").unwrap();
-            write!(manim, "\\clip ").unwrap();
+            writeln!(manim, "# Being scope?").unwrap();
             for (_, path) in &layer {
                 let left = offset(-OCCLUSION_DELTA, path).reversed();
                 let right = offset(OCCLUSION_DELTA, path);
@@ -87,33 +86,25 @@ pub fn render(diagram: &Diagram, stylesheet: &str) -> Result<String, DimensionEr
                 manim.push_str(&render_path(&left));
                 manim.push_str(" -- cycle");
             }
-            writeln!(manim, ";").unwrap();
-            writeln!(manim, "\\Background").unwrap();
-            writeln!(manim, "\\end{{scope}}").unwrap();
         }
 
         for (g, path) in &layer {
-            write!(manim, "\\draw[{}!80, line width=5pt] ", color(*g)).unwrap();
-            manim.push_str(&render_path(path));
-            writeln!(manim, ";").unwrap();
+            writeln!(manim, "{ind}{ind}path_{id}_{dim} = VMobject(stroke_color={color},stroke_width=8).set_fill({color}, 1.0){path}\n{ind}{ind}self.play(Create(path_{id}_{dim}))\n",
+            ind=INDENT,color=color(*g),id=g.id,dim=g.dimension,path=&render_path(path)).unwrap();
         }
     }
 
     // Points
     for (g, point) in points {
-        write!(manim, "\\fill[{}] ", color(g)).unwrap();
-        manim.push_str(&render_point(point));
-        writeln!(manim, " circle (4pt);").unwrap();
+        writeln!(manim, "{ind}{ind}circle_{id}_{dim} = Circle(radius=0.125,color={color},fill_opacity=1).move_to({pt})\n{ind}{ind}self.play(Create(circle_{id}_{dim}))\n{ind}{ind}self.wait(1)", ind=INDENT,id=g.id,dim=g.dimension,color=color(g),pt=&render_point(point)).unwrap();
     }
-
-    writeln!(manim, "\\end{{tikzpicture}}").unwrap();
 
     Ok(manim)
 }
 
 fn render_point(point: Point2D<f32>) -> String {
-    let x = (point.x * 100.0).round() / 100.0;
-    let y = (point.y * 100.0).round() / 100.0;
+    let x = ((point.x) * 100.0).round() / 100.0;
+    let y = ((point.y) * 100.0).round() / 100.0;
     format!("[{},{},0]", x, y)
 }
 

--- a/homotopy-web/src/app/sidebar/buttons.rs
+++ b/homotopy-web/src/app/sidebar/buttons.rs
@@ -121,4 +121,10 @@ declare_sidebar_tools! {
         "download",
         model::Action::ExportSvg,
     }
+
+    BUTTON_MANIM {
+        "Export to Manim Python",
+        "download",
+        model::Action::ExportManim,
+    }
 }

--- a/homotopy-web/src/model.rs
+++ b/homotopy-web/src/model.rs
@@ -187,7 +187,7 @@ impl State {
                 for info in signature.iter() {
                     writeln!(
                         stylesheet,
-                        "{generator} = \"#{r:02x}{g:02x}{b:02x}\"",
+                        "            \"{generator}\": \"#{r:02x}{g:02x}{b:02x}\",",
                         generator = manim::color(info.generator),
                         r = info.color.red,
                         g = info.color.green,


### PR DESCRIPTION
This PR introduces an additional exporting option available for 2D diagrams to export them into basic Python code, using manim (community edition) as a rendering engine.
This allows for powerful mathematical animations by offering a good template off which to create custom animations involving homotopy.io diagrams. It also effectively gives access to a completely independent rendering engine to test out ideas.

The Python code produced is relatively clean, but it will benefit significantly from the wire/surfaces simplification code, which should drastically reduce the amount of rendering primitives issued (and thus the size of the script produced by the exporter).
