### PR TITLE
Path simplification and wire merging

### DIFF
--- a/homotopy-graphics/src/lib.rs
+++ b/homotopy-graphics/src/lib.rs
@@ -46,6 +46,7 @@ pub mod buffers;
 pub mod geom;
 pub mod gl;
 pub mod parity;
+pub mod path_util;
 pub mod subdivision;
 pub mod svg;
 pub mod tikz;

--- a/homotopy-graphics/src/path_util.rs
+++ b/homotopy-graphics/src/path_util.rs
@@ -24,15 +24,12 @@ pub fn simplify_graphic<const N: usize>(graphic: &[GraphicElement<N>]) -> Vec<Gr
                 // Recycle the builder if possible!
                 //TODO handle reversal case
                 // Use builder.current_position
-                match entry.last_mut() {
-                    Some(last) => {
-                        last.extend(path.iter());
-                    }
-                    _ => {
-                        let mut builder = Path::builder();
-                        builder.extend(path.iter());
-                        entry.push(builder);
-                    }
+                if let Some(last) = entry.last_mut() {
+                    last.extend(path.iter());
+                } else {
+                    let mut builder = Path::builder();
+                    builder.extend(path.iter());
+                    entry.push(builder);
                 }
             }
             GraphicElement::Point { .. } => {

--- a/homotopy-graphics/src/path_util.rs
+++ b/homotopy-graphics/src/path_util.rs
@@ -1,0 +1,216 @@
+use euclid::Vector2D;
+use lyon_geom::{CubicBezierSegment, Line, LineSegment};
+use lyon_path::{Event, Path};
+
+use crate::svg::geom::Point;
+
+// Test collinearity with dot product formula up to precision
+fn points_collinear(p0: Point, p1: Point, p2: Point) -> bool {
+    ((p1.x - p0.x) * (p2.y - p0.y) - (p1.y - p0.y) * (p2.x - p0.x)).abs() <= 0.00005
+}
+
+pub fn simplify_path(path: &Path) -> Path {
+    //TODO either make a hot-path for Begin - UselessBezierCubic -- End, or do not call on unmerged wires.
+    let mut builder = Path::builder();
+    let mut it = path.iter();
+    let mut under_cons: Option<lyon_path::PathEvent> = it.next();
+    let mut peek_head: Option<lyon_path::PathEvent> = it.next();
+    loop {
+        //  Do not assume under_cons == peek_head of previous iteration.
+        //  We want to rewrite it.
+        match (under_cons, peek_head) {
+            // Get rid of peek_head == None cases first
+            (None, None) => {
+                break;
+            }
+            (Some(ev), None) => {
+                builder.path_event(ev);
+                break;
+            }
+            // Now can assume there is a next element!
+            (None, Some(_)) => {
+                // I don't think this should ever happen
+                // But we won't issue a warning to avoid I/O
+                // in potential rendering loop.
+                under_cons = peek_head;
+                peek_head = it.next();
+            }
+            // Collinear lines can be merged
+            (
+                Some(lyon_path::Event::Line {
+                    from: from1,
+                    to: to1,
+                }),
+                Some(lyon_path::Event::Line {
+                    from: from2,
+                    to: to2,
+                }),
+            ) if to1 == from2 && points_collinear(from1, to1, to2) => {
+                under_cons = Some(lyon_path::Event::Line {
+                    from: from1,
+                    to: to2,
+                });
+                peek_head = it.next();
+            }
+            // Collinear Beziers can be transformed to lines
+            (_, Some(lyon_path::Event::Quadratic { from, ctrl, to }))
+                if points_collinear(from, ctrl, to) =>
+            {
+                peek_head = Some(lyon_path::Event::Line { from, to });
+            }
+            (
+                _,
+                Some(lyon_path::Event::Cubic {
+                    from,
+                    ctrl1,
+                    ctrl2,
+                    to,
+                }),
+            ) if points_collinear(ctrl1, ctrl2, to) => {
+                peek_head = Some(lyon_path::Event::Line { from, to });
+            }
+            // Needless End -- Begin can be removed
+            (
+                Some(lyon_path::Event::End {
+                    last, close: false, ..
+                }),
+                Some(lyon_path::Event::Begin { at }),
+            ) if last == at => {
+                under_cons = it.next();
+                peek_head = it.next();
+            }
+            (Some(ev), _) => {
+                builder.path_event(ev);
+                under_cons = peek_head;
+                peek_head = it.next();
+            }
+        };
+    }
+    builder.build()
+}
+
+// Offsetting a curve.
+pub fn offset(delta: f32, path: &Path) -> Path {
+    let mut flag = false;
+    let mut builder = Path::builder();
+
+    for event in path {
+        match event {
+            Event::Cubic {
+                from,
+                ctrl1,
+                ctrl2,
+                to,
+            } => {
+                let segment = offset_cubical(
+                    delta,
+                    CubicBezierSegment {
+                        from,
+                        ctrl1,
+                        ctrl2,
+                        to,
+                    },
+                );
+                if !flag {
+                    builder.begin(segment.from);
+                    flag = true;
+                }
+                builder.cubic_bezier_to(segment.ctrl1, segment.ctrl2, segment.to);
+            }
+            // TODO handle Quadratic properly
+            Event::Line { from, to } | Event::Quadratic { from, to, .. } => {
+                let segment = offset_linear(delta, LineSegment { from, to });
+                if !flag {
+                    builder.begin(segment.from);
+                    flag = true;
+                }
+                builder.line_to(segment.to);
+            }
+            _ => (),
+        }
+    }
+    builder.end(false);
+    builder.build()
+}
+
+fn perp<U>(v: Vector2D<f32, U>) -> Vector2D<f32, U> {
+    Vector2D::new(v.y, -v.x).normalize()
+}
+
+fn offset_linear(delta: f32, segment: LineSegment<f32>) -> LineSegment<f32> {
+    let v = perp(segment.to - segment.from);
+    LineSegment {
+        from: segment.from + v * delta,
+        to: segment.to + v * delta,
+    }
+}
+
+fn offset_cubical(delta: f32, segment: CubicBezierSegment<f32>) -> CubicBezierSegment<f32> {
+    if segment.from == segment.ctrl1
+        || segment.ctrl1 == segment.ctrl2
+        || segment.ctrl2 == segment.to
+    {
+        let leg = offset_linear(
+            delta,
+            LineSegment {
+                from: segment.from,
+                to: segment.to,
+            },
+        );
+        CubicBezierSegment {
+            from: leg.from,
+            ctrl1: leg.from,
+            ctrl2: leg.to,
+            to: leg.to,
+        }
+    } else {
+        let leg1 = offset_linear(
+            delta,
+            LineSegment {
+                from: segment.from,
+                to: segment.ctrl1,
+            },
+        );
+        let leg2 = offset_linear(
+            delta,
+            LineSegment {
+                from: segment.ctrl1,
+                to: segment.ctrl2,
+            },
+        );
+        let leg3 = offset_linear(
+            delta,
+            LineSegment {
+                from: segment.ctrl2,
+                to: segment.to,
+            },
+        );
+
+        let from = leg1.from;
+
+        let line1 = Line {
+            point: leg1.from,
+            vector: leg1.to - leg1.from,
+        };
+        let line2 = Line {
+            point: leg2.from,
+            vector: leg2.to - leg2.from,
+        };
+        let line3 = Line {
+            point: leg3.from,
+            vector: leg3.to - leg3.from,
+        };
+
+        let ctrl1 = line1.intersection(&line2).unwrap_or(leg1.to);
+        let ctrl2 = line2.intersection(&line3).unwrap_or(leg2.to);
+
+        let to = leg3.to;
+
+        CubicBezierSegment {
+            from,
+            ctrl1,
+            ctrl2,
+            to,
+        }
+    }
+}

--- a/homotopy-graphics/src/svg/render.rs
+++ b/homotopy-graphics/src/svg/render.rs
@@ -11,9 +11,12 @@ use homotopy_core::{
 use lyon_path::Path;
 
 use super::geom::project_2d;
-use crate::svg::geom::{Circle, Fill, Point, Shape, Stroke};
+use crate::{
+    path_util::simplify_path,
+    svg::geom::{Circle, Fill, Point, Shape, Stroke},
+};
 
-pub type Coordinate<const N: usize> = [SliceIndex; N];
+type Coordinate<const N: usize> = [SliceIndex; N];
 
 /// An action region in the diagram.
 ///
@@ -205,7 +208,8 @@ impl<const N: usize> GraphicElement<N> {
                 make_path(&points, true, layout, projection, &mut path_builder);
             }
 
-            let path = path_builder.build();
+            // Quick enough to do it every time
+            let path = simplify_path(&path_builder.build());
 
             surface_elements.push(Self::Surface(generator, path));
         }

--- a/homotopy-graphics/src/tikz.rs
+++ b/homotopy-graphics/src/tikz.rs
@@ -33,8 +33,8 @@ pub fn render(diagram: &Diagram, stylesheet: &str) -> Result<String, DimensionEr
     for element in graphic {
         match element {
             GraphicElement::Surface(g, path) => surfaces.push((g, path)),
-            GraphicElement::Wire(g, path, mask) => {
-                wires.entry(mask.len()).or_default().push((g, path));
+            GraphicElement::Wire(g, depth, path, _) => {
+                wires.entry(depth).or_default().push((g, path));
             }
             GraphicElement::Point(g, point) => points.push((g, point)),
         }

--- a/homotopy-graphics/src/tikz.rs
+++ b/homotopy-graphics/src/tikz.rs
@@ -12,7 +12,10 @@ use homotopy_core::{
 use itertools::Itertools;
 use lyon_path::{Event, Path};
 
-use crate::{path_util::offset, svg::render::GraphicElement};
+use crate::{
+    path_util::{offset, simplify_graphic},
+    svg::render::GraphicElement,
+};
 
 const OCCLUSION_DELTA: f32 = 0.2;
 
@@ -25,7 +28,12 @@ pub fn render(diagram: &Diagram, stylesheet: &str) -> Result<String, DimensionEr
     let complex = make_complex(diagram);
     let depths = Depths::<2>::new(diagram)?;
     let projection = Projection::<2>::new(diagram, &layout, &depths)?;
-    let graphic = GraphicElement::build(&complex, &layout, &projection, &depths);
+    let graphic = simplify_graphic(&GraphicElement::build(
+        &complex,
+        &layout,
+        &projection,
+        &depths,
+    ));
 
     let mut surfaces = Vec::default();
     let mut wires: FastHashMap<usize, Vec<(Generator, Path)>> = FastHashMap::default();

--- a/homotopy-web/src/app/diagram_svg.rs
+++ b/homotopy-web/src/app/diagram_svg.rs
@@ -338,7 +338,7 @@ impl<const N: usize> DiagramSvg<N> {
                     <path d={path} class={class} stroke-width={1} />
                 }
             }
-            GraphicElement::Wire(_, path, mask) => {
+            GraphicElement::Wire(_, _, path, mask) => {
                 let class = SignatureStylesheet::name("generator", generator, "wire");
                 let path = path_to_svg(&path.clone().transformed(&self.prepared.transform));
 


### PR DESCRIPTION
This is PR is Part 1/2 of work to clean up the output of (human readable) exporters, e.g. issue #533.

It add a path_util.rs, which contains two key functions:
- The first one is the path simplifier: it takes lyon paths and removes unnecessary drawing primitives. This is very easy to call in a stand-alone fashion from various renderers.
- The other is the graphic simplifier. This this consumes the entire GraphicElement vector to be rendered, and does some more drastic simplifications by merging wires, while respecting the masking. Note that this function is mostly meant for the tikz/manim exports, as it discards the SVG masking!

This closes #537 and #538, and partly addresses #533 (Eckmann-Hilton .tikz export has been reduced by circa 60%).