### PR TITLE
Unpin rust 1.59

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,11 +103,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657802959,
-        "narHash": "sha256-9+JWARSdlL8KiH3ymnKDXltE1vM+/WEJ78F5B1kjXys=",
+        "lastModified": 1658161305,
+        "narHash": "sha256-X/nhnMCa1Wx4YapsspyAs6QYz6T/85FofrI6NpdPDHg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4a01ca36d6bfc133bc617e661916a81327c9bbc8",
+        "rev": "e4d49de45a3b5dbcb881656b4e3986e666141ea9",
         "type": "github"
       },
       "original": {
@@ -138,11 +138,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657939629,
-        "narHash": "sha256-8lX/pZNetbLCN2cW/O+vUz1rG8ig4RaVX5PWe5m4VLA=",
+        "lastModified": 1658285378,
+        "narHash": "sha256-AL3tLo8sF9w14RGTqGnyKiUkvnLH41xH4l5qAK4/JWs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2cd36d4aef875867ee1d7963541ccb3ae50b358c",
+        "rev": "8b4b3c2b4257a0dcbd9c7d61191782fe17155cf4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -127,7 +127,7 @@
           };
         };
         defaultPackage = let
-          rust = pkgs.rust-bin.stable."1.59.0".minimal.override { # TODO: 1.60.0 crashes
+          rust = pkgs.rust-bin.stable.latest.minimal.override {
             targets = ["wasm32-unknown-unknown"];
           };
           naersk = inputs.naersk.lib."${system}".override {

--- a/homotopy-core/src/diagram.rs
+++ b/homotopy-core/src/diagram.rs
@@ -629,7 +629,7 @@ impl Iterator for Slices {
     }
 }
 
-impl<'a> ExactSizeIterator for Slices {
+impl ExactSizeIterator for Slices {
     fn len(&self) -> usize {
         if self.current.is_none() {
             0
@@ -642,7 +642,7 @@ impl<'a> ExactSizeIterator for Slices {
     }
 }
 
-impl<'a> std::iter::FusedIterator for Slices {}
+impl std::iter::FusedIterator for Slices {}
 
 pub struct Embeddings(Box<dyn Iterator<Item = Vec<RegularHeight>>>);
 

--- a/homotopy-core/src/lib.rs
+++ b/homotopy-core/src/lib.rs
@@ -22,7 +22,6 @@
     clippy::unneeded_field_pattern,
     clippy::unreachable,
     clippy::use_debug,
-    clippy::use_self,
 )]
 #![allow( // pedantic is too annoying
     clippy::cast_possible_truncation,
@@ -44,7 +43,8 @@
     clippy::multiple_inherent_impl,
     clippy::shadow_unrelated,
     clippy::match_on_vec_items,
-    clippy::unnecessary_wraps
+    clippy::unnecessary_wraps,
+    clippy::use_self, // https://github.com/rust-lang/rust-clippy/issues/6902
 )]
 
 pub use common::{Boundary, Direction, Generator, Height, SliceIndex};

--- a/homotopy-graphics/src/gl/array.rs
+++ b/homotopy-graphics/src/gl/array.rs
@@ -118,7 +118,7 @@ impl VertexArray {
     }
 }
 
-impl<'ctx> Drop for VertexArray {
+impl Drop for VertexArray {
     #[inline]
     fn drop(&mut self) {
         self.ctx.with_gl(|gl| {

--- a/homotopy-graphics/src/gl/buffer.rs
+++ b/homotopy-graphics/src/gl/buffer.rs
@@ -71,7 +71,7 @@ pub struct ElementBuffer {
     pub(super) kind: ElementKind,
 }
 
-impl<'ctx> UntypedBuffer {
+impl UntypedBuffer {
     #[inline]
     pub(super) fn bind<F, U>(&self, f: F) -> U
     where

--- a/homotopy-graphics/src/gl/shader.rs
+++ b/homotopy-graphics/src/gl/shader.rs
@@ -100,7 +100,7 @@ impl<'ctx> UntypedShader {
     }
 }
 
-impl<'ctx> Drop for UntypedShader {
+impl Drop for UntypedShader {
     #[inline]
     fn drop(&mut self) {
         self.ctx

--- a/homotopy-web/src/lib.rs
+++ b/homotopy-web/src/lib.rs
@@ -22,7 +22,6 @@
     clippy::unneeded_field_pattern,
     clippy::unreachable,
     clippy::use_debug,
-    clippy::use_self,
 )]
 #![allow( // pedantic is too annoying
     clippy::cast_possible_truncation,
@@ -46,6 +45,7 @@
     clippy::unreachable,
     clippy::unused_unit,
     clippy::shadow_unrelated,
+    clippy::use_self, // https://github.com/rust-lang/rust-clippy/issues/6902
 )]
 #![recursion_limit = "1024"]
 

--- a/homotopy-web/src/model.rs
+++ b/homotopy-web/src/model.rs
@@ -30,16 +30,16 @@ impl Action {
         use homotopy_core::Direction::{Backward, Forward};
 
         match self {
-            Action::Proof(action) => proof.is_valid(action),
-            Action::ExportTikz | Action::ExportSvg | Action::ExportManim => proof
+            Self::Proof(action) => proof.is_valid(action),
+            Self::ExportTikz | Self::ExportSvg | Self::ExportManim => proof
                 .workspace
                 .as_ref()
                 .map_or(false, |ws| ws.view.dimension() == 2),
-            Action::ExportStl => proof
+            Self::ExportStl => proof
                 .workspace
                 .as_ref()
                 .map_or(false, |ws| ws.view.dimension() == 3),
-            Action::History(history::Action::Move(dir)) => match dir {
+            Self::History(history::Action::Move(dir)) => match dir {
                 history::Direction::Linear(Forward) => proof.can_redo(),
                 history::Direction::Linear(Backward) => proof.can_undo(),
             },

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.59.0"
+channel = "stable"
 components = [ "rustfmt", "clippy", "rust-src" ]
 targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
Now that https://github.com/rust-lang/rust/issues/96672 is fixed, we can move to the current version of rust stable. PR to ensure CI is happy.