### PR TITLE
Substantial improvements to signature UI

### DIFF
--- a/homotopy-graphics/src/style.rs
+++ b/homotopy-graphics/src/style.rs
@@ -36,6 +36,13 @@ impl Color {
         Self(palette::Lighten::lighten(self.0.into_linear(), amount).into())
     }
 
+    pub fn is_light(&self) -> bool {
+        palette::RelativeContrast::get_contrast_ratio(
+            palette::Srgb::new(1., 1., 1.),
+            self.0.into_format::<f32>(),
+        ) < 1.5
+    }
+
     pub fn into_components<T>(self) -> (T, T, T)
     where
         T: palette::stimulus::FromStimulus<u8>,

--- a/homotopy-web/src/app.rs
+++ b/homotopy-web/src/app.rs
@@ -1,5 +1,5 @@
 use boundary::BoundaryPreview;
-use settings::AppSettings;
+use settings::{AppSettings, AppSettingsKey};
 use sidebar::Sidebar;
 use signature_stylesheet::SignatureStylesheet;
 use wasm_bindgen::{closure::Closure, JsCast};

--- a/homotopy-web/src/app/settings.rs
+++ b/homotopy-web/src/app/settings.rs
@@ -14,6 +14,7 @@ declare_settings! {
         subdivision_depth: u32 = 2,
         geometry_samples: u32 = 10,
 
+        show_previews: bool = true,
         orthographic_3d: bool = false,
         specularity: u32 = 25,
         shininess: u32 = 64,
@@ -104,6 +105,13 @@ impl Component for SettingsView {
                 </div>
                 <div class="settings__segment">
                     <h4>{"Style"}</h4>
+                    {
+                        self.view_checkbox(
+                            "Show previews in signature",
+                            |local| *local.get_show_previews(),
+                            AppSettingsDispatch::set_show_previews,
+                        )
+                    }
                     {
                         self.view_checkbox(
                             "Orthographic projection",

--- a/homotopy-web/src/app/signature.rs
+++ b/homotopy-web/src/app/signature.rs
@@ -20,7 +20,7 @@ pub fn signature_view(props: &Props) -> Html {
     html! {
         <FolderView
             dispatch={props.dispatch.clone()}
-            contents={props.signature.as_tree()}
+            signature={props.signature.clone()}
         />
     }
 }

--- a/homotopy-web/src/app/signature/folder.rs
+++ b/homotopy-web/src/app/signature/folder.rs
@@ -132,6 +132,8 @@ fn render_drop_zone(props: &Props, node: Node, position: DropPosition) -> Html {
 
     html! {
         <li
+            // TODO: in future, we may wish to add keys to the dropzones, though it is not strictly
+            // necessary
             ref={drop_zone_ref}
             class="signature__dropzone"
             ondragenter={on_drag_enter}
@@ -147,9 +149,10 @@ fn render_item(props: &Props, node: Node) -> Html {
         .signature
         .as_tree()
         .with(node, |item| match item.inner() {
-            SignatureItem::Folder(_, _) => {
+            SignatureItem::Folder(info) => {
                 html! {
                     <ItemView
+                        key={format!("f-{}", info.id)}
                         dispatch={props.dispatch.clone()}
                         node={node}
                         item={item.inner().clone()}
@@ -161,9 +164,10 @@ fn render_item(props: &Props, node: Node) -> Html {
                     />
                 }
             }
-            SignatureItem::Item(_) => {
+            SignatureItem::Item(info) => {
                 html! {
                     <ItemView
+                        key={format!("i-{}", info.generator.id)}
                         dispatch={props.dispatch.clone()}
                         node={node}
                         item={item.inner().clone()}
@@ -178,7 +182,7 @@ fn render_item(props: &Props, node: Node) -> Html {
 fn render_children(props: &Props, node: Node) -> Html {
     let contents = props.signature.as_tree();
     contents.with(node, move |n| match n.inner() {
-        SignatureItem::Folder(_, true) => {
+        SignatureItem::Folder(info) if info.open => {
             let children = n.children().map(|child| render_tree(props, child));
             let class = format!(
                 "signature__branch {}",

--- a/homotopy-web/src/app/signature/folder.rs
+++ b/homotopy-web/src/app/signature/folder.rs
@@ -177,7 +177,6 @@ fn render_item(props: &Props, node: Node) -> Html {
 
 fn render_children(props: &Props, node: Node) -> Html {
     let contents = props.signature.as_tree();
-    let root = contents.root();
     contents.with(node, move |n| match n.inner() {
         SignatureItem::Folder(_, true) => {
             let children = n.children().map(|child| render_tree(props, child));

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -340,18 +340,24 @@ impl ItemView {
         }
 
         if let SignatureItem::Item(ref info) = ctx.props().item {
-            let svg_of = |diagram: Diagram| match diagram.dimension() {
-                0 => Self::view_diagram_svg::<0>(ctx, diagram),
-                1 => Self::view_diagram_svg::<1>(ctx, diagram),
-                _ => Self::view_diagram_svg::<2>(ctx, diagram),
+            let svg_of = |diagram: Diagram, id: String| match diagram.dimension() {
+                0 => Self::view_diagram_svg::<0>(ctx, diagram, id),
+                1 => Self::view_diagram_svg::<1>(ctx, diagram, id),
+                _ => Self::view_diagram_svg::<2>(ctx, diagram, id),
             };
 
             let diagrams = match &info.diagram {
-                Diagram::Diagram0(_) => svg_of(info.diagram.clone()),
+                Diagram::Diagram0(_) => svg_of(
+                    info.diagram.clone(),
+                    "signature__generator-preview".to_owned(),
+                ),
                 Diagram::DiagramN(diagram_n) => html! {
                     <>
-                        {svg_of(diagram_n.source())}
-                        {svg_of(diagram_n.target())}
+                        {svg_of(diagram_n.source(), "signature__generator-preview-source".to_owned())}
+                        <div class="signature__generator-preview-spacer">
+                            <div class="signature__generator-preview-source-target-symbol">{"\u{21DD}"}</div>
+                        </div>
+                        {svg_of(diagram_n.target(), "signature__generator-preview-source".to_owned())}
                     </>
                 },
             };
@@ -364,11 +370,11 @@ impl ItemView {
         }
     }
 
-    fn view_diagram_svg<const N: usize>(ctx: &Context<Self>, diagram: Diagram) -> Html {
+    fn view_diagram_svg<const N: usize>(ctx: &Context<Self>, diagram: Diagram, id: String) -> Html {
         html! {
             <DiagramSvg<N>
                     diagram={diagram}
-                    id="item__preview"
+                    id={id}
                     signature={ctx.props().signature.clone()}
                     max_width={Some(42.0)}
                     max_height={Some(32.0)}

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -248,14 +248,20 @@ impl Component for ItemView {
         let item = &ctx.props().item;
 
         let class = format!(
-            "signature__item {}",
-            match (self.mode, item) {
-                (ItemViewMode::Editing, SignatureItem::Item(info)) => format!(
-                    "signature__item-editing signature__item-generator-{}",
-                    info.generator.dimension
-                ),
-                (ItemViewMode::Editing, _) => "signature__folder-editing".to_owned(),
-                (_, _) => "".to_owned(),
+            "signature__item signature__{item} signature__{item}-{mode} {generator_dimension}",
+            item = match item {
+                SignatureItem::Item(_) => "generator",
+                SignatureItem::Folder(_) => "folder",
+            },
+            mode = match self.mode {
+                ItemViewMode::Editing => "editing",
+                ItemViewMode::Hovering => "hovering",
+                ItemViewMode::Viewing => "viewing",
+            },
+            generator_dimension = match item {
+                SignatureItem::Item(info) =>
+                    format!("signature__generator-{}d", info.generator.dimension),
+                SignatureItem::Folder(_) => "".to_owned(),
             }
         );
 

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -543,7 +543,7 @@ impl ItemView {
             SignatureItem::Item(info) => {
                 html! {
                     <>
-                        <span class="signature__item-child">
+                        <span class="signature__item-child signature__generator-dimension">
                             {info.diagram.dimension()}
                         </span>
                         {self.view_name(ctx)}

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -621,6 +621,7 @@ impl ItemView {
 
     fn view_right_buttons(&self, ctx: &Context<Self>) -> Html {
         if let SignatureItem::Folder(info) = &ctx.props().item {
+            let node = ctx.props().node;
             let class = format!(
                 "signature__folder-right {}",
                 match self.mode {
@@ -631,8 +632,7 @@ impl ItemView {
             );
 
             let buttons = match self.mode {
-                ItemViewMode::Viewing => html! {},
-                ItemViewMode::Hovering => {
+                ItemViewMode::Viewing | ItemViewMode::Hovering => {
                     let new_folder = if info.open {
                         html! {
                             <NewFolderButton
@@ -661,11 +661,18 @@ impl ItemView {
                     }
                 }
                 ItemViewMode::Editing => html! {
-                    <ItemViewButton icon={"done"} on_click={
-                        ctx.link().callback(move |_| {
-                            ItemViewMessage::SwitchTo(ItemViewMode::Hovering)
-                        })
-                    } />
+                    <>
+                        <ItemViewButton icon={"delete"} on_click={
+                            ctx.props().dispatch.reform(
+                                move |_| Action::EditSignature(SignatureEdit::Remove(node))
+                            )
+                        } />
+                        <ItemViewButton icon={"done"} on_click={
+                            ctx.link().callback(move |_| {
+                                ItemViewMessage::SwitchTo(ItemViewMode::Hovering)
+                            })
+                        } />
+                    </>
                 },
             };
 

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -271,6 +271,7 @@ impl Component for ItemView {
                     <div class="signature__item-info">
                         {self.view_left_buttons(ctx)}
                         {self.view_info(ctx)}
+                        {self.view_property_indicators(ctx)}
                         {Self::view_preview(ctx)}
                         {self.view_right_buttons(ctx)}
                     </div>
@@ -589,6 +590,45 @@ impl ItemView {
                 node={ctx.props().node}
                 kind={NewFolderKind::Inline}
                 />
+            }
+        } else {
+            html! {}
+        }
+    }
+
+    fn view_property_indicators(&self, ctx: &Context<Self>) -> Html {
+        if self.mode == ItemViewMode::Editing {
+            return html! {};
+        }
+
+        if let SignatureItem::Item(ref info) = ctx.props().item {
+            // To avoid unnecessary String operations, we define all classes beforehand
+            let invertible_class =
+                "signature__generator-indicator signature__generator-indicator-invertible";
+            let oriented_class =
+                "signature__generator-indicator signature__generator-indicator-oriented";
+
+            let invertible = if info.invertible {
+                html! {
+                    <span class={invertible_class}>{"I"}</span>
+                }
+            } else {
+                html! {}
+            };
+
+            let oriented = if info.framed {
+                html! {}
+            } else {
+                html! {
+                    <span class={oriented_class}>{"O"}</span>
+                }
+            };
+
+            html! {
+                <div class="signature__generator-indicators-wrapper">
+                    {invertible}
+                    {oriented}
+                </div>
             }
         } else {
             html! {}

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -464,13 +464,17 @@ impl ItemView {
                 VertexShape::Circle => "circle",
                 VertexShape::Square => "square",
             };
-            let mut class = "signature__generator-picker-preset".to_owned();
-            if *shape == selected_shape {
-                class += " signature__generator-picker-preset-shape-selected";
-            }
+            let style = format!(
+                "color: {}",
+                if *shape == selected_shape {
+                    selected_color.hex()
+                } else {
+                    "var(--drawer-foreground)".to_owned()
+                },
+            );
 
             html! {
-                <div {class} onclick={reshape}>
+                <div class="signature__generator-picker-preset" style={style} onclick={reshape}>
                     <Icon name={icon_name} size={IconSize::Icon18} />
                 </div>
             }

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -772,7 +772,7 @@ impl ItemView {
                         color={color.clone()}
                         onclick={toggle_framed}
                         checked={!info.framed}
-                        disabled={info.framed}
+                        disabled={!info.framed}
                     />
                 </div>
             },

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -440,9 +440,7 @@ impl ItemView {
                         html! {
                             <>
                                 {svg_of(diagram_n.source(), "signature__generator-preview-source".to_owned())}
-                                <div class="signature__generator-preview-spacer">
-                                    <span class="signature__generator-preview-source-target-symbol">{"\u{1F86A}"}</span>
-                                </div>
+                                <div class="signature__generator-preview-spacer" />
                                 {svg_of(diagram_n.target(), "signature__generator-preview-source".to_owned())}
                             </>
                         }

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -343,12 +343,14 @@ impl ItemView {
             }
         } else {
             html! {
-                <span
+                <div
                     class="signature__item-child signature__item-name"
                     onclick={on_click}
                 >
-                    {name}
-                </span>
+                    <span class="signature__item-name">
+                        {name}
+                    </span>
+                </div>
             }
         }
     }
@@ -378,19 +380,30 @@ impl ItemView {
                     info.diagram.clone(),
                     "signature__generator-preview".to_owned(),
                 ),
-                Diagram::DiagramN(diagram_n) => html! {
-                    <>
-                        {svg_of(diagram_n.source(), "signature__generator-preview-source".to_owned())}
-                        <div class="signature__generator-preview-spacer">
-                            <div class="signature__generator-preview-source-target-symbol">{"\u{21DD}"}</div>
-                        </div>
-                        {svg_of(diagram_n.target(), "signature__generator-preview-source".to_owned())}
-                    </>
-                },
+                Diagram::DiagramN(diagram_n) => {
+                    if info.single_preview {
+                        svg_of(
+                            info.diagram.clone(),
+                            "signature__generator-preview".to_owned(),
+                        )
+                    } else {
+                        html! {
+                            <>
+                                {svg_of(diagram_n.source(), "signature__generator-preview-source".to_owned())}
+                                <div class="signature__generator-preview-spacer">
+                                    <div class="signature__generator-preview-source-target-symbol">{"\u{21DD}"}</div>
+                                </div>
+                                {svg_of(diagram_n.target(), "signature__generator-preview-source".to_owned())}
+                            </>
+                        }
+                    }
+                }
             };
 
             html! {
-                {diagrams}
+                <div class="signature__generator-previews-wrapper">
+                    {diagrams}
+                </div>
             }
         } else {
             html! {}
@@ -488,10 +501,10 @@ impl ItemView {
             SignatureItem::Item(info) => {
                 html! {
                     <>
-                        {self.view_name(ctx)}
                         <span class="signature__item-child">
                             {info.diagram.dimension()}
                         </span>
+                        {self.view_name(ctx)}
                     </>
                 }
             }
@@ -594,6 +607,11 @@ impl ItemView {
             let input: HtmlInputElement = div.last_element_child().unwrap().unchecked_into();
             ItemViewMessage::Edit(SignatureItemEdit::MakeInvertible(!input.checked()))
         });
+        let toggle_single_preview = ctx.link().callback(move |e: MouseEvent| {
+            let div: HtmlElement = e.target_unchecked_into();
+            let input: HtmlInputElement = div.last_element_child().unwrap().unchecked_into();
+            ItemViewMessage::Edit(SignatureItemEdit::ShowSinglePreview(!input.checked()))
+        });
 
         match info.generator.dimension {
             0 => Html::default(),
@@ -610,6 +628,11 @@ impl ItemView {
                         onclick={toggle_invertible}
                         checked={info.invertible}
                         disabled={info.invertible}
+                    />
+                    <GeneratorPreferenceCheckbox
+                        name="Single Preview"
+                        onclick={toggle_single_preview}
+                        checked={info.single_preview}
                     />
                 </>
             },

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -197,7 +197,7 @@ impl Component for ItemView {
     fn create(ctx: &Context<Self>) -> Self {
         let name = match &ctx.props().item {
             SignatureItem::Item(info) => info.name.clone(),
-            SignatureItem::Folder(name, _) => name.clone(),
+            SignatureItem::Folder(info) => info.name.clone(),
         };
         Self {
             name,
@@ -273,7 +273,7 @@ impl Component for ItemView {
                     .dispatch
                     .reform(move |_| Action::SelectGenerator(generator))
             }
-            SignatureItem::Folder(_, _) => Callback::noop(),
+            SignatureItem::Folder(_) => Callback::noop(),
         };
 
         html! {
@@ -313,7 +313,7 @@ impl ItemView {
         if mode == ItemViewMode::Viewing {
             let prev_name = match &ctx.props().item {
                 SignatureItem::Item(info) => &info.name,
-                SignatureItem::Folder(name, _) => name,
+                SignatureItem::Folder(info) => &info.name,
             };
             if &self.name != prev_name {
                 apply_edit(
@@ -331,7 +331,7 @@ impl ItemView {
     fn view_name(&self, ctx: &Context<Self>) -> Html {
         let name = match &ctx.props().item {
             SignatureItem::Item(info) => &info.name,
-            SignatureItem::Folder(name, _) => name,
+            SignatureItem::Folder(info) => &info.name,
         };
 
         if self.mode == ItemViewMode::Editing {
@@ -550,8 +550,8 @@ impl ItemView {
                     </>
                 }
             }
-            SignatureItem::Folder(_, open) => {
-                let icon = if *open { "folder_open" } else { "folder" };
+            SignatureItem::Folder(info) => {
+                let icon = if info.open { "folder_open" } else { "folder" };
                 let node = ctx.props().node;
                 let toggle = ctx
                     .props()
@@ -620,7 +620,7 @@ impl ItemView {
     }
 
     fn view_right_buttons(&self, ctx: &Context<Self>) -> Html {
-        if let SignatureItem::Folder(_, open) = ctx.props().item {
+        if let SignatureItem::Folder(info) = &ctx.props().item {
             let class = format!(
                 "signature__folder-right {}",
                 match self.mode {
@@ -633,7 +633,7 @@ impl ItemView {
             let buttons = match self.mode {
                 ItemViewMode::Viewing => html! {},
                 ItemViewMode::Hovering => {
-                    let new_folder = if open {
+                    let new_folder = if info.open {
                         html! {
                             <NewFolderButton
                                 dispatch={ctx.props().dispatch.clone()}

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -391,7 +391,7 @@ impl ItemView {
                             <>
                                 {svg_of(diagram_n.source(), "signature__generator-preview-source".to_owned())}
                                 <div class="signature__generator-preview-spacer">
-                                    <div class="signature__generator-preview-source-target-symbol">{"\u{21DD}"}</div>
+                                    <span class="signature__generator-preview-source-target-symbol">{"\u{1F86A}"}</span>
                                 </div>
                                 {svg_of(diagram_n.target(), "signature__generator-preview-source".to_owned())}
                             </>

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -473,18 +473,15 @@ impl ItemView {
                 VertexShape::Circle => "circle",
                 VertexShape::Square => "square",
             };
-            let style = format!(
-                "color: {};",
-                if *shape == selected_shape {
-                    selected_color.hex()
-                } else {
-                    "var(--drawer-foreground)".to_owned()
-                },
-            );
+            let icon_class = if *shape == selected_shape {
+                ""
+            } else {
+                "md-inactive"
+            };
 
             html! {
-                <div class="signature__generator-picker-preset" style={style} onclick={reshape}>
-                    <Icon name={icon_name} size={IconSize::Icon18} />
+                <div class="signature__generator-picker-preset" onclick={reshape}>
+                    <Icon name={icon_name} size={IconSize::Icon18} class={icon_class} />
                 </div>
             }
         });

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -498,7 +498,11 @@ impl ItemView {
                         oninput={custom_recolor}
                         onkeyup={ctx.link().callback(move |e: KeyboardEvent| {
                             e.stop_propagation();
-                            ItemViewMessage::Noop
+                            if e.key().to_ascii_lowercase() == "enter" {
+                                ItemViewMessage::SwitchTo(ItemViewMode::Viewing)
+                            } else {
+                                ItemViewMessage::Noop
+                            }
                         })}
                     />
                 </div>

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -4,7 +4,7 @@ use homotopy_common::tree::Node;
 use homotopy_core::Diagram;
 use homotopy_graphics::style::{Color, VertexShape};
 use wasm_bindgen::JsCast;
-use web_sys::{HtmlElement, HtmlInputElement};
+use web_sys::{Element, HtmlInputElement};
 use yew::prelude::*;
 use yew_macro::function_component;
 
@@ -641,44 +641,51 @@ impl ItemView {
         }
 
         // The following is required to allow the div to respond to onclick events appropriately.
+        let get_input = move |e: MouseEvent| {
+            e.target_unchecked_into::<Element>()
+                .last_child()
+                .unwrap()
+                .unchecked_into::<HtmlInputElement>()
+        };
+
         let toggle_single_preview = ctx.link().callback(move |e: MouseEvent| {
-            let div: HtmlElement = e.target_unchecked_into();
-            let input: HtmlInputElement = div.last_element_child().unwrap().unchecked_into();
-            ItemViewMessage::Edit(SignatureItemEdit::ShowSinglePreview(!input.checked()))
+            ItemViewMessage::Edit(SignatureItemEdit::ShowSinglePreview(get_input(e).checked()))
         });
         let toggle_invertible = ctx.link().callback(move |e: MouseEvent| {
-            let div: HtmlElement = e.target_unchecked_into();
-            let input: HtmlInputElement = div.last_element_child().unwrap().unchecked_into();
-            ItemViewMessage::Edit(SignatureItemEdit::MakeInvertible(!input.checked()))
+            ItemViewMessage::Edit(SignatureItemEdit::MakeInvertible(!get_input(e).checked()))
         });
         let toggle_framed = ctx.link().callback(move |e: MouseEvent| {
-            let div: HtmlElement = e.target_unchecked_into();
-            let input: HtmlInputElement = div.last_element_child().unwrap().unchecked_into();
-            ItemViewMessage::Edit(SignatureItemEdit::MakeFramed(!input.checked()))
+            ItemViewMessage::Edit(SignatureItemEdit::MakeFramed(get_input(e).checked()))
         });
 
         match info.generator.dimension {
             0 => Html::default(),
             _ => html! {
-                <>
+                <div class="signature__generator-preferences-wrapper">
                     <GeneratorPreferenceCheckbox
-                        name="Single Preview"
+                        left="Single Preview"
+                        right="Source-Target"
+                        color={info.color.clone()}
                         onclick={toggle_single_preview}
-                        checked={info.single_preview}
+                        checked={!info.single_preview}
                     />
                     <GeneratorPreferenceCheckbox
-                        name="Invertible"
+                        left="Directed"
+                        right="Invertible"
+                        color={info.color.clone()}
                         onclick={toggle_invertible}
                         checked={info.invertible}
                         disabled={info.invertible}
                     />
                     <GeneratorPreferenceCheckbox
-                        name="Framed"
+                        left="Framed"
+                        right="Oriented"
+                        color={info.color.clone()}
                         onclick={toggle_framed}
-                        checked={info.framed}
-                        disabled={!info.framed}
+                        checked={!info.framed}
+                        disabled={info.framed}
                     />
-                </>
+                </div>
             },
         }
     }

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -597,20 +597,20 @@ impl ItemView {
         }
 
         // The following is required to allow the div to respond to onclick events appropriately.
-        let toggle_framed = ctx.link().callback(move |e: MouseEvent| {
+        let toggle_single_preview = ctx.link().callback(move |e: MouseEvent| {
             let div: HtmlElement = e.target_unchecked_into();
             let input: HtmlInputElement = div.last_element_child().unwrap().unchecked_into();
-            ItemViewMessage::Edit(SignatureItemEdit::MakeFramed(!input.checked()))
+            ItemViewMessage::Edit(SignatureItemEdit::ShowSinglePreview(!input.checked()))
         });
         let toggle_invertible = ctx.link().callback(move |e: MouseEvent| {
             let div: HtmlElement = e.target_unchecked_into();
             let input: HtmlInputElement = div.last_element_child().unwrap().unchecked_into();
             ItemViewMessage::Edit(SignatureItemEdit::MakeInvertible(!input.checked()))
         });
-        let toggle_single_preview = ctx.link().callback(move |e: MouseEvent| {
+        let toggle_framed = ctx.link().callback(move |e: MouseEvent| {
             let div: HtmlElement = e.target_unchecked_into();
             let input: HtmlInputElement = div.last_element_child().unwrap().unchecked_into();
-            ItemViewMessage::Edit(SignatureItemEdit::ShowSinglePreview(!input.checked()))
+            ItemViewMessage::Edit(SignatureItemEdit::MakeFramed(!input.checked()))
         });
 
         match info.generator.dimension {
@@ -618,10 +618,9 @@ impl ItemView {
             _ => html! {
                 <>
                     <GeneratorPreferenceCheckbox
-                        name="Framed"
-                        onclick={toggle_framed}
-                        checked={info.framed}
-                        disabled={!info.framed}
+                        name="Single Preview"
+                        onclick={toggle_single_preview}
+                        checked={info.single_preview}
                     />
                     <GeneratorPreferenceCheckbox
                         name="Invertible"
@@ -630,9 +629,10 @@ impl ItemView {
                         disabled={info.invertible}
                     />
                     <GeneratorPreferenceCheckbox
-                        name="Single Preview"
-                        onclick={toggle_single_preview}
-                        checked={info.single_preview}
+                        name="Framed"
+                        onclick={toggle_framed}
+                        checked={info.framed}
+                        disabled={!info.framed}
                     />
                 </>
             },

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -563,11 +563,11 @@ impl ItemView {
                                 ItemViewMessage::SwitchTo(Hovering)
                             })
                         } />
-                    <ItemViewButton icon={"delete"} light={icon_light} on_click={
-                        ctx.props().dispatch.reform(
-                            move |_| Action::EditSignature(SignatureEdit::Remove(node))
-                            )
-                    } />
+                        <ItemViewButton icon={"delete"} light={icon_light} on_click={
+                            ctx.props().dispatch.reform(
+                                move |_| Action::EditSignature(SignatureEdit::Remove(node))
+                                )
+                        } />
                     </>
                 }
             } else {
@@ -592,36 +592,57 @@ impl ItemView {
 
     fn view_right_buttons(&self, ctx: &Context<Self>) -> Html {
         if let SignatureItem::Folder(_, open) = ctx.props().item {
-            let class = if self.mode == ItemViewMode::Hovering {
-                "signature__folder-right signature__folder-right-hover"
-            } else {
-                "signature__folder-right"
-            };
+            let class = format!(
+                "signature__folder-right {}",
+                match self.mode {
+                    ItemViewMode::Viewing => "",
+                    ItemViewMode::Hovering => "signature__folder-right-hover",
+                    ItemViewMode::Editing => "signature__folder-right-editing",
+                },
+            );
 
-            let new_folder = if open {
-                html! {
-                    <NewFolderButton
-                        dispatch={ctx.props().dispatch.clone()}
-                        node={ctx.props().node}
-                        kind={NewFolderKind::Inline}
-                    />
+            let buttons = match self.mode {
+                ItemViewMode::Viewing => html! {},
+                ItemViewMode::Hovering => {
+                    let new_folder = if open {
+                        html! {
+                            <NewFolderButton
+                                dispatch={ctx.props().dispatch.clone()}
+                                node={ctx.props().node}
+                                kind={NewFolderKind::Inline}
+                            />
+                        }
+                    } else {
+                        html! {}
+                    };
+
+                    let settings = html! {
+                        <ItemViewButton icon={"settings"} on_click={
+                            ctx.link().callback(move |_| {
+                                ItemViewMessage::SwitchTo(ItemViewMode::Editing)
+                            })
+                        } />
+                    };
+
+                    html! {
+                        <>
+                            {new_folder}
+                            {settings}
+                        </>
+                    }
                 }
-            } else {
-                html! {}
-            };
-
-            let settings = html! {
-                <ItemViewButton icon={"settings"} on_click={
-                    ctx.link().callback(move |_| {
-                        ItemViewMessage::SwitchTo(ItemViewMode::Editing)
-                    })
-                } />
+                ItemViewMode::Editing => html! {
+                    <ItemViewButton icon={"done"} on_click={
+                        ctx.link().callback(move |_| {
+                            ItemViewMessage::SwitchTo(ItemViewMode::Hovering)
+                        })
+                    } />
+                },
             };
 
             html! {
                 <div class={class}>
-                    {new_folder}
-                    {settings}
+                    {buttons}
                 </div>
             }
         } else {

--- a/homotopy-web/src/app/signature/item/preference.rs
+++ b/homotopy-web/src/app/signature/item/preference.rs
@@ -1,9 +1,12 @@
+use homotopy_graphics::style::Color;
 use yew::prelude::*;
 
 #[derive(Properties, Debug, Clone, PartialEq)]
 pub struct GeneratorPreferenceCheckboxProps {
-    pub name: &'static str,
+    pub left: &'static str,
+    pub right: &'static str,
     pub tooltip: Option<&'static str>,
+    pub color: Color,
     pub checked: bool,
     pub onclick: Callback<MouseEvent>,
     #[prop_or(false)]
@@ -21,14 +24,29 @@ impl Component for GeneratorPreferenceCheckbox {
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {
+        let color = ctx.props().color.hex();
+
+        let border_style = format!("border: 1px solid {};", color);
+
+        let slider_style = format!(
+            "transform: translateX({}); background-color: {};",
+            if ctx.props().checked { "100%" } else { "0" },
+            color
+        );
+
         html! {
             <div
                 class={"signature__generator-preference"}
                 onclick={ctx.props().onclick.clone()}
+                style={border_style}
             >
-                <span>{ctx.props().name}</span>
+                <div class="signature__generator-preference-options-wrapper">
+                    <div class="signature__generator-preference-option">{ctx.props().left}</div>
+                    <div class="signature__generator-preference-option">{ctx.props().right}</div>
+                </div>
+                <div class="signature__generator-preference-slider" style={slider_style} />
                 <input
-                    type={"checkbox"}
+                    type="checkbox"
                     checked={ctx.props().checked}
                     disabled={ctx.props().disabled}
                 />

--- a/homotopy-web/src/app/signature/item/preference.rs
+++ b/homotopy-web/src/app/signature/item/preference.rs
@@ -1,4 +1,3 @@
-use homotopy_graphics::style::Color;
 use yew::prelude::*;
 
 #[derive(Properties, Debug, Clone, PartialEq)]
@@ -6,7 +5,7 @@ pub struct GeneratorPreferenceCheckboxProps {
     pub left: &'static str,
     pub right: &'static str,
     pub tooltip: Option<&'static str>,
-    pub color: Color,
+    pub color: String,
     pub checked: bool,
     pub onclick: Callback<MouseEvent>,
     #[prop_or(false)]
@@ -24,15 +23,29 @@ impl Component for GeneratorPreferenceCheckbox {
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {
-        let color = ctx.props().color.hex();
+        let color_main = &ctx.props().color;
+        let color_text_on = "var(--drawer-background)";
+        let color_text_off = "var(--drawer-foreground)";
 
-        let border_style = format!("border: 1px solid {};", color);
+        let border_style = format!("border: 1px solid {};", color_main);
 
         let slider_style = format!(
             "transform: translateX({}); background-color: {};",
             if ctx.props().checked { "100%" } else { "0" },
-            color
+            color_main,
         );
+
+        let (left_style, right_style) = if ctx.props().checked {
+            (
+                format!("color: {};", color_text_off),
+                format!("color: {};", color_text_on),
+            )
+        } else {
+            (
+                format!("color: {};", color_text_on),
+                format!("color: {};", color_text_off),
+            )
+        };
 
         html! {
             <div
@@ -41,8 +54,12 @@ impl Component for GeneratorPreferenceCheckbox {
                 style={border_style}
             >
                 <div class="signature__generator-preference-options-wrapper">
-                    <div class="signature__generator-preference-option">{ctx.props().left}</div>
-                    <div class="signature__generator-preference-option">{ctx.props().right}</div>
+                    <div class="signature__generator-preference-option" style={left_style}>
+                        {ctx.props().left}
+                    </div>
+                    <div class="signature__generator-preference-option" style={right_style}>
+                        {ctx.props().right}
+                    </div>
                 </div>
                 <div class="signature__generator-preference-slider" style={slider_style} />
                 <input

--- a/homotopy-web/src/app/signature/item/preference.rs
+++ b/homotopy-web/src/app/signature/item/preference.rs
@@ -24,28 +24,36 @@ impl Component for GeneratorPreferenceCheckbox {
 
     fn view(&self, ctx: &Context<Self>) -> Html {
         let color_main = &ctx.props().color;
+        let color_disabled = "var(--drawer-foreground-dimmed)";
         let color_text_on = "var(--drawer-background)";
         let color_text_off = "var(--drawer-foreground)";
+        let color_text_disabled = "var(--drawer-foreground-dimmed-text)";
 
-        let border_style = format!("border: 1px solid {};", color_main);
+        let color = if ctx.props().disabled {
+            color_disabled
+        } else {
+            color_main
+        };
+
+        let border_style = format!("border: 1px solid {};", color);
 
         let slider_style = format!(
             "transform: translateX({}); background-color: {};",
             if ctx.props().checked { "100%" } else { "0" },
-            color_main,
+            color,
         );
 
-        let (left_style, right_style) = if ctx.props().checked {
-            (
-                format!("color: {};", color_text_off),
-                format!("color: {};", color_text_on),
-            )
+        let (left_color, right_color) = if ctx.props().disabled {
+            (color_text_disabled, color_text_disabled)
+        } else if ctx.props().checked {
+            (color_text_off, color_text_on)
         } else {
-            (
-                format!("color: {};", color_text_on),
-                format!("color: {};", color_text_off),
-            )
+            (color_text_on, color_text_off)
         };
+        let (left_style, right_style) = (
+            format!("color: {};", left_color),
+            format!("color: {};", right_color),
+        );
 
         html! {
             <div

--- a/homotopy-web/src/components/icon.rs
+++ b/homotopy-web/src/components/icon.rs
@@ -5,6 +5,8 @@ use yew_macro::function_component;
 pub struct Props {
     pub name: String,
     pub size: IconSize,
+    #[prop_or(false)]
+    pub light: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -18,7 +20,8 @@ pub enum IconSize {
 #[function_component(Icon)]
 pub fn icon(props: &Props) -> Html {
     let class = format!(
-        "material-icons md-light {}",
+        "material-icons md-{} {}",
+        if props.light { "light" } else { "dark" },
         match props.size {
             IconSize::Icon18 => "md-18",
             IconSize::Icon24 => "md-24",

--- a/homotopy-web/src/components/icon.rs
+++ b/homotopy-web/src/components/icon.rs
@@ -7,6 +7,8 @@ pub struct Props {
     pub size: IconSize,
     #[prop_or(false)]
     pub light: bool,
+    #[prop_or_default]
+    pub class: &'static str,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -20,14 +22,15 @@ pub enum IconSize {
 #[function_component(Icon)]
 pub fn icon(props: &Props) -> Html {
     let class = format!(
-        "material-icons md-{} {}",
+        "material-icons md-{} {} {}",
         if props.light { "light" } else { "dark" },
         match props.size {
             IconSize::Icon18 => "md-18",
             IconSize::Icon24 => "md-24",
             /* IconSize::Icon36 => "md-36",
              * IconSize::Icon48 => "md-48", */
-        }
+        },
+        props.class,
     );
 
     html! {

--- a/homotopy-web/src/model/proof/generators.rs
+++ b/homotopy-web/src/model/proof/generators.rs
@@ -10,6 +10,7 @@ pub struct GeneratorInfo {
     pub name: String,
     pub framed: bool,
     pub invertible: bool,
+    pub single_preview: bool,
     pub color: Color,
     pub shape: VertexShape,
     pub diagram: Diagram,

--- a/homotopy-web/src/model/proof/signature.rs
+++ b/homotopy-web/src/model/proof/signature.rs
@@ -99,9 +99,9 @@ impl Signature {
             name: format!("{} {}", name, id),
             framed: true,
             invertible: false,
-            single_preview: !matches!(generator.dimension, 1 | 2),
+            single_preview: matches!(generator.dimension, 1 | 2),
             color: Color::from_str(COLORS[id % COLORS.len()]).unwrap(),
-            shape: VERTEX_SHAPES[(id / COLORS.len()) % VERTEX_SHAPES.len()].clone(),
+            shape: Default::default(),
             diagram: diagram.into(),
         };
 

--- a/homotopy-web/src/model/proof/signature.rs
+++ b/homotopy-web/src/model/proof/signature.rs
@@ -14,7 +14,7 @@ pub const COLORS: &[&str] = &[
     "#8e44ad", // wisteria
     "#27ae60", // nephritis
     "#f1c40f", // sunflower
-    "#ffffff", // white
+    "#f6f5f4", // white(ish)
     "#000000", // black
 ];
 

--- a/homotopy-web/src/model/proof/signature.rs
+++ b/homotopy-web/src/model/proof/signature.rs
@@ -39,6 +39,7 @@ pub enum SignatureItemEdit {
     Reshape(VertexShape),
     MakeFramed(bool),
     MakeInvertible(bool),
+    ShowSinglePreview(bool),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -82,6 +83,7 @@ impl Signature {
             name: format!("{} {}", name, id),
             framed: true,
             invertible: false,
+            single_preview: !matches!(generator.dimension, 1 | 2),
             color: Color::from_str(COLORS[id % COLORS.len()]).unwrap(),
             shape: VertexShape::default(),
             diagram: diagram.into(),
@@ -98,13 +100,16 @@ impl Signature {
     }
 
     fn edit(&mut self, node: Node, edit: SignatureItemEdit) {
-        use SignatureItemEdit::{MakeFramed, MakeInvertible, Recolor, Rename, Reshape};
+        use SignatureItemEdit::{
+            MakeFramed, MakeInvertible, Recolor, Rename, Reshape, ShowSinglePreview,
+        };
         self.0.with_mut(node, move |n| match (n.inner_mut(), edit) {
             (SignatureItem::Item(info), Rename(name)) => info.name = name,
             (SignatureItem::Item(info), Recolor(color)) => info.color = color,
             (SignatureItem::Item(info), Reshape(shape)) => info.shape = shape,
             (SignatureItem::Item(info), MakeFramed(false)) => info.framed = false,
             (SignatureItem::Item(info), MakeInvertible(true)) => info.invertible = true,
+            (SignatureItem::Item(info), ShowSinglePreview(show)) => info.single_preview = show,
             (SignatureItem::Folder(ref mut old, _), Rename(name)) => *old = name,
             (_, _) => {}
         });

--- a/homotopy-web/src/model/proof/signature.rs
+++ b/homotopy-web/src/model/proof/signature.rs
@@ -22,13 +22,17 @@ pub const VERTEX_SHAPES: &[VertexShape] = &[VertexShape::Circle, VertexShape::Sq
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum SignatureItem {
-    Folder(String, bool),
+    Folder(FolderInfo),
     Item(GeneratorInfo),
 }
 
 impl Default for SignatureItem {
     fn default() -> Self {
-        Self::Folder("".to_owned(), true)
+        Self::Folder(FolderInfo {
+            id: 0,
+            name: "".to_owned(),
+            open: true,
+        })
     }
 }
 
@@ -59,7 +63,7 @@ impl Signature {
     pub fn iter(&self) -> impl Iterator<Item = &GeneratorInfo> {
         self.0.iter().filter_map(|(_, data)| match data.inner() {
             SignatureItem::Item(info) => Some(info),
-            &SignatureItem::Folder(_, _) => None,
+            &SignatureItem::Folder(_) => None,
         })
     }
 
@@ -70,6 +74,18 @@ impl Signature {
     fn next_generator_id(&self) -> usize {
         self.iter()
             .map(|info| info.generator.id)
+            .max()
+            .map_or(0, |id| id + 1)
+    }
+
+    fn next_folder_id(&self) -> usize {
+        self.0
+            .iter()
+            .filter_map(|(_, data)| match data.inner() {
+                SignatureItem::Item(_) => None,
+                SignatureItem::Folder(info) => Some(info),
+            })
+            .map(|info| info.id)
             .max()
             .map_or(0, |id| id + 1)
     }
@@ -110,7 +126,7 @@ impl Signature {
             (SignatureItem::Item(info), MakeFramed(false)) => info.framed = false,
             (SignatureItem::Item(info), MakeInvertible(true)) => info.invertible = true,
             (SignatureItem::Item(info), ShowSinglePreview(show)) => info.single_preview = show,
-            (SignatureItem::Folder(ref mut old, _), Rename(name)) => *old = name,
+            (SignatureItem::Folder(info), Rename(name)) => info.name = name,
             (_, _) => {}
         });
     }
@@ -156,8 +172,14 @@ impl Signature {
         match edit {
             SignatureEdit::Edit(node, edit) => self.edit(*node, edit.clone()),
             SignatureEdit::NewFolder(node) => {
-                self.0
-                    .push_onto(*node, SignatureItem::Folder("New folder".to_owned(), true));
+                self.0.push_onto(
+                    *node,
+                    SignatureItem::Folder(FolderInfo {
+                        id: self.next_folder_id(),
+                        name: "New folder".to_owned(),
+                        open: true,
+                    }),
+                );
             }
             SignatureEdit::MoveBefore(from, to) => {
                 if !self.0.descendents_of(*from).any(|node| node == *to) {
@@ -171,8 +193,8 @@ impl Signature {
             }
             SignatureEdit::ToggleFolder(node) => {
                 self.0.with_mut(*node, |n| {
-                    if let SignatureItem::Folder(_, b) = n.inner_mut() {
-                        *b = !*b;
+                    if let SignatureItem::Folder(info) = n.inner_mut() {
+                        info.open = !info.open;
                     }
                 });
             }
@@ -218,4 +240,11 @@ impl From<Tree<SignatureItem>> for Signature {
     fn from(tree: Tree<SignatureItem>) -> Self {
         Self(tree)
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FolderInfo {
+    pub id: usize,
+    pub name: String,
+    pub open: bool,
 }

--- a/homotopy-web/src/model/proof/signature.rs
+++ b/homotopy-web/src/model/proof/signature.rs
@@ -85,7 +85,7 @@ impl Signature {
             invertible: false,
             single_preview: !matches!(generator.dimension, 1 | 2),
             color: Color::from_str(COLORS[id % COLORS.len()]).unwrap(),
-            shape: VertexShape::default(),
+            shape: VERTEX_SHAPES[(id / COLORS.len()) % VERTEX_SHAPES.len()].clone(),
             diagram: diagram.into(),
         };
 

--- a/homotopy-web/src/model/serialize.rs
+++ b/homotopy-web/src/model/serialize.rs
@@ -203,7 +203,7 @@ pub fn deserialize(data: &[u8]) -> Option<(Signature, Option<Workspace>)> {
                     framed: true,
                     invertible: false,
                     // TODO: `single_preview` should be properly serialized
-                    single_preview: !matches!(gd.generator.dimension, 1 | 2),
+                    single_preview: matches!(gd.generator.dimension, 1 | 2),
                 }),
             })
         })

--- a/homotopy-web/src/model/serialize.rs
+++ b/homotopy-web/src/model/serialize.rs
@@ -13,7 +13,7 @@ use obake::AnyVersion;
 use wasm_bindgen::JsCast;
 
 use super::{
-    proof::{generators::GeneratorInfo, SignatureItem, View},
+    proof::{generators::GeneratorInfo, FolderInfo, SignatureItem, View},
     Signature, Workspace,
 };
 
@@ -145,7 +145,7 @@ pub fn serialize(signature: Signature, workspace: Option<Workspace>) -> Vec<u8> 
     signature.clean_up();
     // Pack signature data
     data.signature = signature.map(|item| match item {
-        SignatureItem::Folder(name, open) => SignatureData::Folder(name, open),
+        SignatureItem::Folder(info) => SignatureData::Folder(info.name, info.open),
         SignatureItem::Item(info) => SignatureData::Item(GeneratorData {
             generator: info.generator,
             diagram: data.store.pack_diagram(&info.diagram),
@@ -181,11 +181,19 @@ pub fn deserialize(data: &[u8]) -> Option<(Signature, Option<Workspace>)> {
     let data: Data = data.into();
     let mut store = data.store;
 
+    let mut folder_index = 0;
     let signature = data
         .signature
         .map(|s| {
             Some(match s {
-                SignatureData::Folder(name, open) => SignatureItem::Folder(name, open),
+                SignatureData::Folder(name, open) => {
+                    folder_index += 1;
+                    SignatureItem::Folder(FolderInfo {
+                        id: folder_index,
+                        name,
+                        open: open.to_owned(),
+                    })
+                }
                 SignatureData::Item(gd) => SignatureItem::Item(GeneratorInfo {
                     generator: gd.generator,
                     name: gd.name,

--- a/homotopy-web/src/model/serialize.rs
+++ b/homotopy-web/src/model/serialize.rs
@@ -194,6 +194,8 @@ pub fn deserialize(data: &[u8]) -> Option<(Signature, Option<Workspace>)> {
                     diagram: store.unpack_diagram(gd.diagram)?,
                     framed: true,
                     invertible: false,
+                    // TODO: `single_preview` should be properly serialized
+                    single_preview: !matches!(gd.generator.dimension, 1 | 2),
                 }),
             })
         })

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -623,9 +623,8 @@ span.signature__item-name {
 
 .signature__generator-preview-spacer {
   box-sizing: border-box;
+  width: 5px;
   height: 18px;
-  font-size: 12px;
-  text-align: center;
 }
 
 .signature__generator-picker {

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -383,6 +383,15 @@ button, .button {
   box-sizing: border-box;
 }
 
+.drawer__content .material-icons.md-light {
+  color: var(--drawer-background);
+}
+
+.drawer__content .material-icons.md-dark {
+  color: var(--drawer-foreground);
+}
+
+
 .drawer__icon {
   cursor: pointer;
   padding: var(--space-1);
@@ -518,7 +527,7 @@ span.signature__item-name {
   user-select: text;
 }
 
-.signature__generator-color {
+.signature__item-color {
   display: flex;
   flex-direction: row;
   wrap: nowrap;
@@ -529,11 +538,11 @@ span.signature__item-name {
   transition: width 50ms;
 }
 
-.signature__generator-color.signature__generator-color-hover {
+.signature__item-color.signature__item-color-hover {
   width: 32px;
 }
 
-.signature__generator-color.signature__generator-color-edit {
+.signature__item-color.signature__item-color-edit {
   width: 64px;
 }
 
@@ -541,6 +550,11 @@ span.signature__item-name {
   flex: 0 0 auto;
   height: 100%;
   width: 6px;
+  box-sizing: border-box;
+}
+
+.signature__generator-color-sliver-light {
+  box-shadow: inset 2px 0 0 #575f6655;
 }
 
 .signature__generator-indicators-wrapper {
@@ -688,7 +702,6 @@ span.signature__item-name {
   justify-content: space-between;
   box-sizing: border-box;
   pointer-events: none;
-  color: var(--drawer-background);
 }
 
 .signature__generator-preferences-wrapper {
@@ -726,6 +739,7 @@ span.signature__item-name {
 .signature__generator-preference-option {
   white-space: nowrap;
   pointer-events: none;
+  transition: color 250ms;
 }
 
 .signature__generator-preference-slider {

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -527,7 +527,19 @@ span.signature__item-name {
   user-select: text;
 }
 
-.signature__item-color {
+.signature__folder-right {
+  display: flex;
+  flex-direction: row;
+  wrap: nowrap;
+  opacity: 0%;
+  transition: opacity 50ms;
+}
+
+.signature__folder-right.signature__folder-right-hover {
+  opacity: 100%;
+}
+
+.signature__generator-color {
   display: flex;
   flex-direction: row;
   wrap: nowrap;
@@ -538,11 +550,11 @@ span.signature__item-name {
   transition: width 50ms;
 }
 
-.signature__item-color.signature__item-color-hover {
+.signature__generator-color.signature__generator-color-hover {
   width: 32px;
 }
 
-.signature__item-color.signature__item-color-edit {
+.signature__generator-color.signature__generator-color-edit {
   width: 64px;
 }
 

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -399,18 +399,20 @@ button, .button {
   height: var(--signature-height);
   overflow: hidden;
   flex-direction: row;
+  align-items: stretch;
   transition: height 100ms;
 }
 
 .signature__item-contents {
-  width: 100%;
+  max-width: calc(100% - 6px);
   height: 100%;
+  flex: 1 0 auto;
   display: flex;
   flex-direction: column;
 }
 
 .signature__item.signature__item-editing {
-  height: 222px;
+  height: 246px;
 }
 
 .signature__item.signature__item-editing.signature__item-generator-0 {
@@ -425,6 +427,7 @@ button, .button {
   display: flex;
   flex-direction: row;
   align-items: stretch;
+  justify-content: center;
   width: 100%;
   height: var(--signature-height);
 }
@@ -484,22 +487,28 @@ button, .button {
 }
 
 .signature__item-name, .signature__item-fill {
-  flex: 1;
+  flex: 1 1 auto;
   white-space: nowrap;
   overflow: hidden;
-  height: 100%;
   box-sizing: border-box;
 }
 
 .signature__item-fill {
-    cursor: pointer;
+  cursor: pointer;
+  height: 100%;
 }
 
-.signature__item-name {
+div.signature__item-name {
   padding-left: 0;
   padding-right: 0;
   border-left: var(--space-1) solid transparent;
   border-right: var(--space-1) solid transparent;
+  display: flex;
+  align-items: center;
+}
+
+span.signature__item-name {
+  text-overflow: ellipsis;
 }
 
 .signature__item-name-input {
@@ -516,6 +525,7 @@ button, .button {
   overflow: hidden;
   color: var(--drawer-background);
   width: 0;
+  flex: 0 0 auto;
   transition: width 50ms;
 }
 
@@ -524,23 +534,23 @@ button, .button {
 }
 
 .signature__generator-color.signature__generator-color-edit {
-  width: 128px;
+  width: 64px;
 }
 
 .signature__generator-color-sliver {
+  flex: 0 0 auto;
   height: 100%;
   width: 6px;
 }
 
-.signature__generator-preview-spacer {
-  position: relative;
-  z-index: 1;
-  width: 5px;
+.signature__generator-previews-wrapper {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: row;
+  pointer-events: none;
 }
 
 .signature__generator-preview-source-target-symbol {
-  position: relative;
-  right: 7px;
   font-size: 25px;
 }
 
@@ -656,7 +666,7 @@ button, .button {
 .signature__generator-preference {
   width: 100%;
   height: 28px;
-  padding: var(--space-0);
+  padding: var(--space-1);
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -543,6 +543,32 @@ span.signature__item-name {
   width: 6px;
 }
 
+.signature__generator-indicators-wrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: right;
+  padding: var(--space-0) 0;
+}
+
+.signature__generator-indicator {
+  border-radius: var(--space-0);
+  width: 18px;
+  color: var(--drawer-background);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 2px;
+  font-weight: bold;
+}
+
+.signature__generator-indicator-invertible {
+  background-color: #2980b9;
+}
+
+.signature__generator-indicator-oriented {
+  background-color: #27ae60;
+}
+
 .signature__generator-previews-wrapper {
   flex: 0 0 auto;
   display: flex;
@@ -571,11 +597,11 @@ span.signature__item-name {
 }
 
 .signature__generator-picker-color {
-    justify-content: space-between;
+  justify-content: space-between;
 }
 
 .signature__generator-picker-shape {
-    justify-content: flex-start;
+  justify-content: flex-start;
 }
 
 .signature__generator-picker-preset {
@@ -585,8 +611,8 @@ span.signature__item-name {
 }
 
 .signature__generator-picker-shape > .signature__generator-picker-preset {
-    flex: 0;
-    transition: color 100ms;
+  flex: 0;
+  transition: color 100ms;
 }
 
 .signature__generator-picker-custom-wrapper {
@@ -680,7 +706,7 @@ span.signature__item-name {
 }
 
 .signature__generator-preference:hover {
-    background-color: var(--drawer-selected);
+  background-color: var(--drawer-selected);
 }
 
 .signature__generator-preference span {

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -13,6 +13,7 @@
   --drawer-background-dimmed: #f1f1f1;
   --drawer-foreground: #575f66;
   --drawer-foreground-dimmed: #575f6655;
+  --drawer-foreground-dimmed-text: #575f66cc;
   --drawer-border: #e1e1e1;
   --drawer-selected: #66aeeb55;
 
@@ -575,6 +576,10 @@ span.signature__item-name {
 
 .signature__generator-color-sliver-light {
   box-shadow: inset 2px 0 0 #575f6655;
+}
+
+.signature__generator-dimension {
+  color: var(--drawer-foreground-dimmed-text);
 }
 
 .signature__generator-indicators-wrapper {

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -12,6 +12,7 @@
   --drawer-background: #f9f9f9;
   --drawer-background-dimmed: #f1f1f1;
   --drawer-foreground: #575f66;
+  --drawer-foreground-dimmed: #575f6655;
   --drawer-border: #e1e1e1;
   --drawer-selected: #66aeeb55;
 
@@ -391,6 +392,9 @@ button, .button {
   color: var(--drawer-foreground);
 }
 
+.drawer__content .material-icons.md-dark.md-inactive {
+  color: var(--drawer-foreground-dimmed);
+}
 
 .drawer__icon {
   cursor: pointer;

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -472,7 +472,6 @@ button, .button {
 .signature__dropzone {
   height: var(--space-1);
   width: 100%;
-  cursor: pointer;
   transition: height 100ms;
 }
 
@@ -676,6 +675,7 @@ span.signature__item-name {
   overflow: hidden;
   flex: 1 1 auto;
   outline: none;
+  cursor: pointer;
   transition: background-color 100ms;
 }
 
@@ -686,7 +686,7 @@ span.signature__item-name {
   box-sizing: border-box;
   overflow: hidden;
   color: var(--drawer-foreground);
-  cursor: pointer;
+  cursor: text;
   outline: none;
   text-align: center;
 }
@@ -697,7 +697,6 @@ span.signature__item-name {
   padding: calc(var(--space-0) + 2px);
   box-sizing: border-box;
   overflow: hidden;
-  cursor: pointer;
   border: none;
   outline: none;
   text-align: center;

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -418,18 +418,22 @@ button, .button {
 }
 
 .signature__item-contents {
-  max-width: calc(100% - 6px);
+  width: 100%;
   height: 100%;
   flex: 1 0 auto;
   display: flex;
   flex-direction: column;
 }
 
-.signature__item.signature__item-editing {
+.signature__generator .signature__item-contents {
+  max-width: calc(100% - 6px);
+}
+
+.signature__item.signature__generator-editing {
   height: 262px;
 }
 
-.signature__item.signature__item-editing.signature__item-generator-0 {
+.signature__item.signature__generator-editing.signature__generator-0d {
   height: 166px;
 }
 
@@ -445,6 +449,8 @@ button, .button {
   width: 100%;
   height: var(--signature-height);
   transition: background-color 100ms;
+  padding-right: 4px;
+  box-sizing: border-box;
 }
 
 @media (pointer: fine) {

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -494,6 +494,10 @@ button, .button {
   height: var(--signature-height);
 }
 
+.signature__item input[type=text]:focus-within {
+  text-decoration: underline;
+}
+
 .signature__item-child {
   padding: var(--space-0);
   display: flex;

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -537,19 +537,19 @@ span.signature__item-name {
 }
 
 .signature__folder-right {
+  flex: 0 0 auto;
   display: flex;
   flex-direction: row;
+  justify-content: right;
   wrap: nowrap;
-  opacity: 0%;
-  transition: opacity 50ms;
+  overflow: hidden;
+  width: 0;
+  transition: width 100ms;
 }
 
-.signature__folder-right.signature__folder-right-hover {
-  opacity: 100%;
-}
-
-.signature__folder-right.signature__folder-right-editing {
-  opacity: 100%;
+.signature__folder-right.signature__folder-right-hover,
+  .signature__folder-right.signature__folder-right-editing {
+  width: 64px;
 }
 
 .signature__generator-color {

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -586,10 +586,7 @@ span.signature__item-name {
 
 .signature__generator-picker-shape > .signature__generator-picker-preset {
     flex: 0;
-}
-
-.signature__generator-picker-preset-shape-selected {
-    color: black;
+    transition: color 100ms;
 }
 
 .signature__generator-picker-custom-wrapper {

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -13,7 +13,7 @@
   --drawer-background-dimmed: #f1f1f1;
   --drawer-foreground: #575f66;
   --drawer-border: #e1e1e1;
-  --drawer-selected: #d1e4f4;
+  --drawer-selected: #66aeeb55;
 
   --button-border: #e1e1e1;
   --button-background: #f0f0f0;
@@ -412,7 +412,7 @@ button, .button {
 }
 
 .signature__item.signature__item-editing {
-  height: 246px;
+  height: 262px;
 }
 
 .signature__item.signature__item-editing.signature__item-generator-0 {
@@ -691,37 +691,60 @@ span.signature__item-name {
   color: var(--drawer-background);
 }
 
-.signature__generator-preference {
+.signature__generator-preferences-wrapper {
   width: 100%;
-  height: 28px;
-  padding: var(--space-1);
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
+  padding: var(--space-0) var(--space-1) 0 var(--space-1);
   box-sizing: border-box;
+}
+
+.signature__generator-preference {
+  position: relative;
+  width: auto;
+  height: 26px;
+  padding: var(--space-0);
+  margin-top: var(--space-0);
   border-radius: var(--space-0);
   transition: background-color 100ms;
   cursor: pointer;
+  box-sizing: border-box;
 }
 
 .signature__generator-preference:hover {
   background-color: var(--drawer-selected);
 }
 
-.signature__generator-preference span {
+.signature__generator-preference-options-wrapper {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
   pointer-events: none;
+}
+
+.signature__generator-preference-option {
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+.signature__generator-preference-slider {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 50%;
+  height: 100%;
+  transition: transform 100ms;
+  pointer-events: none;
+  z-index: -1;
 }
 
 .signature__generator-preference input[type=checkbox] {
-  width: 18px;
-  height: 18px;
-  cursor: pointer;
-  pointer-events: none;
-}
-
-.signature__generator-preference select {
-  height: 18px;
+  opacity: 0;
+  width: 0;
+  height: 0;
 }
 
 /* Diagram SVG */

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -539,6 +539,10 @@ span.signature__item-name {
   opacity: 100%;
 }
 
+.signature__folder-right.signature__folder-right-editing {
+  opacity: 100%;
+}
+
 .signature__generator-color {
   display: flex;
   flex-direction: row;

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -547,11 +547,16 @@ span.signature__item-name {
   flex: 0 0 auto;
   display: flex;
   flex-direction: row;
+  align-items: center;
+  justify-content: center;
   pointer-events: none;
 }
 
-.signature__generator-preview-source-target-symbol {
-  font-size: 25px;
+.signature__generator-preview-spacer {
+  box-sizing: border-box;
+  height: 18px;
+  font-size: 12px;
+  text-align: center;
 }
 
 .signature__generator-picker {

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -398,8 +398,15 @@ button, .button {
   cursor: pointer;
   height: var(--signature-height);
   overflow: hidden;
-  flex-direction: column;
+  flex-direction: row;
   transition: height 100ms;
+}
+
+.signature__item-contents {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .signature__item.signature__item-editing {
@@ -420,7 +427,6 @@ button, .button {
   align-items: stretch;
   width: 100%;
   height: var(--signature-height);
-  margin-bottom: var(--space-0);
 }
 
 .signature__branch {
@@ -504,7 +510,26 @@ button, .button {
 }
 
 .signature__generator-color {
+  display: flex;
+  flex-direction: row;
+  wrap: nowrap;
+  overflow: hidden;
   color: var(--drawer-background);
+  width: 0;
+  transition: width 50ms;
+}
+
+.signature__generator-color.signature__generator-color-hover {
+  width: 32px;
+}
+
+.signature__generator-color.signature__generator-color-edit {
+  width: 128px;
+}
+
+.signature__generator-color-sliver {
+  height: 100%;
+  width: 6px;
 }
 
 .signature__generator-preview-spacer {
@@ -525,7 +550,7 @@ button, .button {
   flex-direction: row;
   flex-wrap: wrap;
   align-items: center;
-  margin-top: var(--space-1);
+  padding: var(--space-1) var(--space-1) 0 var(--space-1);
   gap: var(--space-0);
   box-sizing: border-box;
 }

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -507,6 +507,18 @@ button, .button {
   color: var(--drawer-background);
 }
 
+.signature__generator-preview-spacer {
+  position: relative;
+  z-index: 1;
+  width: 5px;
+}
+
+.signature__generator-preview-source-target-symbol {
+  position: relative;
+  right: 7px;
+  font-size: 25px;
+}
+
 .signature__generator-picker {
   width: 100%;
   display: flex;

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -443,7 +443,15 @@ button, .button {
   justify-content: center;
   width: 100%;
   height: var(--signature-height);
+  transition: background-color 100ms;
 }
+
+@media (pointer: fine) {
+  .signature__item-info:hover {
+    background: var(--drawer-selected);
+  }
+}
+
 
 .signature__branch {
   width: 100%;
@@ -490,13 +498,6 @@ button, .button {
   padding: var(--space-0);
   display: flex;
   align-items: center;
-  transition: background-color 100ms;
-}
-
-@media (pointer: fine) {
-  .signature__item-child:hover {
-    background: var(--drawer-selected);
-  }
 }
 
 .signature__item-name, .signature__item-fill {


### PR DESCRIPTION
This should allow the user to (optionally) preview each generator in the signature panel.

It should allow the user to toggle between generator previews and source/target previews.