### PR TITLE
`Yew` keys for signature items and folders

### DIFF
--- a/homotopy-web/src/app/signature/folder.rs
+++ b/homotopy-web/src/app/signature/folder.rs
@@ -132,6 +132,8 @@ fn render_drop_zone(props: &Props, node: Node, position: DropPosition) -> Html {
 
     html! {
         <li
+            // TODO: in future, we may wish to add keys to the dropzones, though it is not strictly
+            // necessary
             ref={drop_zone_ref}
             class="signature__dropzone"
             ondragenter={on_drag_enter}
@@ -147,9 +149,10 @@ fn render_item(props: &Props, node: Node) -> Html {
         .signature
         .as_tree()
         .with(node, |item| match item.inner() {
-            SignatureItem::Folder(_, _) => {
+            SignatureItem::Folder(info) => {
                 html! {
                     <ItemView
+                        key={format!("f-{}", info.id)}
                         dispatch={props.dispatch.clone()}
                         node={node}
                         item={item.inner().clone()}
@@ -161,9 +164,10 @@ fn render_item(props: &Props, node: Node) -> Html {
                     />
                 }
             }
-            SignatureItem::Item(_) => {
+            SignatureItem::Item(info) => {
                 html! {
                     <ItemView
+                        key={format!("i-{}", info.generator.id)}
                         dispatch={props.dispatch.clone()}
                         node={node}
                         item={item.inner().clone()}
@@ -178,7 +182,7 @@ fn render_item(props: &Props, node: Node) -> Html {
 fn render_children(props: &Props, node: Node) -> Html {
     let contents = props.signature.as_tree();
     contents.with(node, move |n| match n.inner() {
-        SignatureItem::Folder(_, true) => {
+        SignatureItem::Folder(info) if info.open => {
             let children = n.children().map(|child| render_tree(props, child));
             let class = format!(
                 "signature__branch {}",

--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -197,7 +197,7 @@ impl Component for ItemView {
     fn create(ctx: &Context<Self>) -> Self {
         let name = match &ctx.props().item {
             SignatureItem::Item(info) => info.name.clone(),
-            SignatureItem::Folder(name, _) => name.clone(),
+            SignatureItem::Folder(info) => info.name.clone(),
         };
         Self {
             name,
@@ -273,7 +273,7 @@ impl Component for ItemView {
                     .dispatch
                     .reform(move |_| Action::SelectGenerator(generator))
             }
-            SignatureItem::Folder(_, _) => Callback::noop(),
+            SignatureItem::Folder(_) => Callback::noop(),
         };
 
         html! {
@@ -313,7 +313,7 @@ impl ItemView {
         if mode == ItemViewMode::Viewing {
             let prev_name = match &ctx.props().item {
                 SignatureItem::Item(info) => &info.name,
-                SignatureItem::Folder(name, _) => name,
+                SignatureItem::Folder(info) => &info.name,
             };
             if &self.name != prev_name {
                 apply_edit(
@@ -331,7 +331,7 @@ impl ItemView {
     fn view_name(&self, ctx: &Context<Self>) -> Html {
         let name = match &ctx.props().item {
             SignatureItem::Item(info) => &info.name,
-            SignatureItem::Folder(name, _) => name,
+            SignatureItem::Folder(info) => &info.name,
         };
 
         if self.mode == ItemViewMode::Editing {
@@ -550,8 +550,8 @@ impl ItemView {
                     </>
                 }
             }
-            SignatureItem::Folder(_, open) => {
-                let icon = if *open { "folder_open" } else { "folder" };
+            SignatureItem::Folder(info) => {
+                let icon = if info.open { "folder_open" } else { "folder" };
                 let node = ctx.props().node;
                 let toggle = ctx
                     .props()
@@ -620,7 +620,7 @@ impl ItemView {
     }
 
     fn view_right_buttons(&self, ctx: &Context<Self>) -> Html {
-        if let SignatureItem::Folder(_, open) = ctx.props().item {
+        if let SignatureItem::Folder(info) = &ctx.props().item {
             let class = format!(
                 "signature__folder-right {}",
                 match self.mode {
@@ -633,7 +633,7 @@ impl ItemView {
             let buttons = match self.mode {
                 ItemViewMode::Viewing => html! {},
                 ItemViewMode::Hovering => {
-                    let new_folder = if open {
+                    let new_folder = if info.open {
                         html! {
                             <NewFolderButton
                                 dispatch={ctx.props().dispatch.clone()}

--- a/homotopy-web/src/model/serialize.rs
+++ b/homotopy-web/src/model/serialize.rs
@@ -13,7 +13,7 @@ use obake::AnyVersion;
 use wasm_bindgen::JsCast;
 
 use super::{
-    proof::{generators::GeneratorInfo, SignatureItem, View},
+    proof::{generators::GeneratorInfo, FolderInfo, SignatureItem, View},
     Signature, Workspace,
 };
 
@@ -145,7 +145,7 @@ pub fn serialize(signature: Signature, workspace: Option<Workspace>) -> Vec<u8> 
     signature.clean_up();
     // Pack signature data
     data.signature = signature.map(|item| match item {
-        SignatureItem::Folder(name, open) => SignatureData::Folder(name, open),
+        SignatureItem::Folder(info) => SignatureData::Folder(info.name, info.open),
         SignatureItem::Item(info) => SignatureData::Item(GeneratorData {
             generator: info.generator,
             diagram: data.store.pack_diagram(&info.diagram),
@@ -181,11 +181,19 @@ pub fn deserialize(data: &[u8]) -> Option<(Signature, Option<Workspace>)> {
     let data: Data = data.into();
     let mut store = data.store;
 
+    let mut folder_index = 0;
     let signature = data
         .signature
         .map(|s| {
             Some(match s {
-                SignatureData::Folder(name, open) => SignatureItem::Folder(name, open),
+                SignatureData::Folder(name, open) => {
+                    folder_index += 1;
+                    SignatureItem::Folder(FolderInfo {
+                        id: folder_index,
+                        name,
+                        open: open.to_owned(),
+                    })
+                }
                 SignatureData::Item(gd) => SignatureItem::Item(GeneratorInfo {
                     generator: gd.generator,
                     name: gd.name,


### PR DESCRIPTION
This aims to fix a long standing issue with `Yew` improperly handling signature items and folders.