### PR TITLE
Better hovering mechanics for signature items

### DIFF
--- a/homotopy-web/src/app/signature/item.rs
+++ b/homotopy-web/src/app/signature/item.rs
@@ -565,16 +565,7 @@ impl ItemView {
 
     fn view_info(&self, ctx: &Context<Self>) -> Html {
         match &ctx.props().item {
-            SignatureItem::Item(info) => {
-                html! {
-                    <>
-                        <span class="signature__item-child signature__generator-dimension">
-                            {info.diagram.dimension()}
-                        </span>
-                        {self.view_name(ctx)}
-                    </>
-                }
-            }
+            SignatureItem::Item(_info) => self.view_name(ctx),
             SignatureItem::Folder(info) => {
                 let icon = if info.open { "folder_open" } else { "folder" };
                 let node = ctx.props().node;
@@ -606,31 +597,49 @@ impl ItemView {
                     Editing => "signature__generator-color-edit",
                 }
             );
+            let dimension_class = format!(
+                "signature__item-child signature__generator-dimension {}",
+                if info.color.is_light() {
+                    ""
+                } else {
+                    "signature__generator-dimension-light"
+                }
+            );
 
-            let inner = if self.mode == Editing {
-                let node = ctx.props().node;
-
-                html! {
+            let inner = match self.mode {
+                Viewing | Hovering => html! {
                     <>
-                        <ItemViewButton icon={"done"} light={icon_light} on_click={
-                            ctx.link().callback(move |_| {
-                                ItemViewMessage::SwitchTo(Hovering)
-                            })
-                        } />
+                        <span class={dimension_class}>
+                            {info.diagram.dimension()}
+                        </span>
+                        <ItemViewButton
+                            icon={"settings"}
+                            light={icon_light}
+                            class="signature__generator-settings-btn"
+                            on_click={
+                                ctx.link().callback(move |_| {
+                                    ItemViewMessage::SwitchTo(Editing)
+                                })
+                            } />
+                    </>
+                },
+                Editing => {
+                    let node = ctx.props().node;
+
+                    html! {
+                        <>
+                            <ItemViewButton icon={"done"} light={icon_light} on_click={
+                                ctx.link().callback(move |_| {
+                                    ItemViewMessage::SwitchTo(Hovering)
+                                })
+                            } />
                         <ItemViewButton icon={"delete"} light={icon_light} on_click={
                             ctx.props().dispatch.reform(
                                 move |_| Action::EditSignature(SignatureEdit::Remove(node))
                                 )
                         } />
-                    </>
-                }
-            } else {
-                html! {
-                    <ItemViewButton icon={"settings"} light={icon_light} on_click={
-                        ctx.link().callback(move |_| {
-                            ItemViewMessage::SwitchTo(Editing)
-                        })
-                    } />
+                        </>
+                    }
                 }
             };
 

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -559,22 +559,39 @@ span.signature__item-name {
 }
 
 .signature__generator-color {
-  display: flex;
-  flex-direction: row;
+  position: relative;
   wrap: nowrap;
   overflow: hidden;
   color: var(--drawer-background);
-  width: 0;
+  width: 26px;
   flex: 0 0 auto;
   transition: width 50ms;
 }
 
-.signature__generator-color.signature__generator-color-hover {
-  width: 32px;
+.signature__generator-color.signature__generator-color-hover,
+.signature__generator-color.signature__generator-color-edit {
+  display: flex;
+  flex-direction: row;
 }
 
 .signature__generator-color.signature__generator-color-edit {
   width: 64px;
+}
+
+.signature__generator-settings-btn {
+  position: absolute;
+  right: 0;
+  box-sizing: border-box;
+  opacity: 0;
+  transition: opacity 100ms;
+}
+
+.signature__generator-color-hover .signature__generator-settings-btn {
+  opacity: 1;
+}
+
+.signature__item-editing .signature__generator-settings-btn {
+  position: static;
 }
 
 .signature__generator-color-sliver {
@@ -589,14 +606,29 @@ span.signature__item-name {
 }
 
 .signature__generator-dimension {
-  color: var(--drawer-foreground-dimmed-text);
+  position: absolute;
+  width: calc(100% + 6px);
+  right: 0;
+  display: block;
+  text-align: center;
+  color: var(--drawer-foreground);
+  font-weight: bold;
+  font-size: 17px;
+  opacity: 1;
+  transition: opacity 100ms;
+  box-sizing: border-box;
+}
+
+.signature__generator-dimension.signature__generator-dimension-light {
+  color: var(--drawer-background);
+}
+
+.signature__generator-color-hover .signature__generator-dimension {
+  opacity: 0;
 }
 
 .signature__generator-indicators-wrapper {
-  display: flex;
-  flex-direction: row;
-  align-items: right;
-  padding: var(--space-0) 0;
+  opacity: 0;
 }
 
 .signature__generator-indicator {

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -566,6 +566,7 @@ span.signature__item-name {
   width: 26px;
   flex: 0 0 auto;
   transition: width 50ms;
+  border-radius: 0 var(--space-0) var(--space-0) 0;
 }
 
 .signature__generator-color.signature__generator-color-hover,


### PR DESCRIPTION
This aims to improve hovering for generators in the signature. Specifically, it aims to stop the generator info from moving with every hover.

Closes #679.