### PR TITLE
Migration tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +210,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +372,16 @@ name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -729,6 +754,7 @@ dependencies = [
  "bimap",
  "cargo-husky",
  "criterion",
+ "flate2",
  "getrandom",
  "hashconsing",
  "highway",
@@ -802,6 +828,7 @@ dependencies = [
  "quote",
  "rmp-serde 0.15.5",
  "serde",
+ "serde_json",
  "syn",
  "thiserror",
  "ultraviolet",
@@ -990,6 +1017,15 @@ checksum = "82a7750a9e5076c660b7bec5e6457b4dbff402b9863c8d112891434e18fd5385"
 dependencies = [
  "log",
  "sprs",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
 ]
 
 [[package]]

--- a/homotopy-core/Cargo.toml
+++ b/homotopy-core/Cargo.toml
@@ -23,6 +23,9 @@ serde = { features = ["derive"], version = "1.0.143" }
 rmp-serde = "1.1.0"
 itertools = "0.10.3"
 thiserror = "1.0.32"
+flate2 = "1.0.24"
+serde_json = "1.0.83"
+base64 = "0.13.0"
 
 [dev-dependencies]
 cargo-husky = { features = ["precommit-hook", "run-cargo-check", "run-cargo-test", "run-cargo-fmt", "run-cargo-clippy"], version = "1.5.0" }

--- a/homotopy-core/src/lib.rs
+++ b/homotopy-core/src/lib.rs
@@ -65,6 +65,7 @@ pub mod factorization;
 pub mod graph;
 pub mod layout;
 pub mod mesh;
+pub mod migration;
 pub mod monotone;
 pub mod normalization;
 pub mod projection;

--- a/homotopy-core/src/migration.rs
+++ b/homotopy-core/src/migration.rs
@@ -163,7 +163,7 @@ impl OldProof {
                     cospans.push(c);
                 }
 
-                log::debug!("forming diagram {}", index);
+                //log::debug!("forming diagram {}", index);
                 DiagramN::new(source, cospans).into()
             }
         };

--- a/homotopy-core/src/migration.rs
+++ b/homotopy-core/src/migration.rs
@@ -1,0 +1,306 @@
+use std::{collections::HashMap, io, io::prelude::*};
+
+use base64::decode;
+use flate2::bufread::ZlibDecoder;
+use serde::Deserialize;
+use serde_json::{from_value, Value};
+use thiserror::Error;
+
+use crate::{rewrite::Cone, Cospan, Diagram, DiagramN, Generator, Rewrite, Rewrite0, RewriteN};
+
+#[derive(Deserialize)]
+pub struct OldProof {
+    head: usize,
+    #[serde(rename = "entries")]
+    _entries: usize,
+    #[serde(rename = "index_to_stored_array")]
+    stored: Vec<Value>,
+    #[serde(skip)]
+    pub generator_info: Vec<OldGeneratorInfo>,
+    #[serde(skip)]
+    generators: HashMap<usize, Generator>,
+    #[serde(skip)]
+    diagrams: HashMap<usize, Diagram>,
+    #[serde(skip)]
+    cones: HashMap<usize, Cone>,
+    #[serde(skip)]
+    rewrites: HashMap<usize, Rewrite>,
+}
+
+pub struct OldGeneratorInfo {
+    pub generator: Generator,
+    pub name: String,
+    pub color: String,
+    pub diagram: Diagram,
+}
+
+impl OldProof {
+    pub fn new(proof_str: &str) -> Result<Self> {
+        // create an old proof object from string
+
+        // atob()
+        let proof_str = decode(proof_str)?;
+        // zlib decompress
+        let proof_str = decode_bufreader(&proof_str)?;
+        // parse json
+        let mut proof: OldProof = serde_json::from_str(&proof_str)?;
+
+        proof.load()?;
+        Ok(proof)
+    }
+
+    fn load(&mut self) -> Result<()> {
+        let generators = self.generators()?;
+        for v in generators {
+            let i: usize = from_value(v["_l"].clone())?;
+            self.load_generator(i)?;
+        }
+        let workspace = self.load_workspace();
+        Ok(())
+    }
+
+    // returns a list of indices to generators and caches them
+    fn generators(&mut self) -> Result<Vec<Value>> {
+        let i: usize = from_value(self.stored[self.head][1]["f"]["signature"]["_l"].clone())?;
+        let i: usize = from_value(self.stored[i][1]["f"]["generators"]["_l"].clone())?;
+        let generators = self.generate_vec(i)?;
+
+        for v in generators.clone() {
+            let index: usize = from_value(v["_l"].clone())?;
+            let info_index: usize =
+                from_value(self.stored[index][1]["f"]["generator"]["_l"].clone())?;
+            let id: String = from_value(self.stored[info_index][1]["f"]["id"].clone())?;
+            let id: usize = id.parse().unwrap();
+            let dim: usize = from_value(self.stored[info_index][1]["n"].clone())?;
+
+            self.generators.insert(id, Generator::new(id, dim));
+        }
+
+        Ok(generators)
+    }
+
+    // turns an encoded array at [index] to a vec
+    fn generate_vec(&mut self, index: usize) -> Result<Vec<Value>> {
+        let map: HashMap<String, Value> = from_value(self.stored[index][1]["f"].clone())?;
+        let mut v: Vec<(String, Value)> = map.into_iter().collect();
+        v.sort_by(|x, y| x.0.cmp(&y.0));
+        let v: Vec<Value> = v.into_iter().map(|x| x.1).collect();
+        Ok(v)
+    }
+
+    fn load_generator(&mut self, index: usize) -> Result<()> {
+        // Extract generator information
+        let name: String = from_value(self.stored[index][1]["f"]["name"].clone())?;
+        let color: String = from_value(self.stored[index][1]["f"]["color"].clone())?;
+
+        //log::debug!("loading {}", name);
+
+        let info_index: usize = from_value(self.stored[index][1]["f"]["generator"]["_l"].clone())?;
+        let id: String = from_value(self.stored[info_index][1]["f"]["id"].clone())?;
+        let id: usize = id.parse().unwrap();
+        let diagram_index: usize =
+            from_value(self.stored[info_index][1]["f"]["diagram"]["_l"].clone())?;
+        let diagram = self.load_diagram(diagram_index)?;
+
+        // Add the diagram into cache
+        self.diagrams.insert(diagram_index, diagram.clone());
+
+        // Format generator info
+        let info = OldGeneratorInfo {
+            generator: self.generators[&id],
+            name,
+            color,
+            diagram,
+        };
+
+        // Insert
+        self.generator_info.push(info);
+        Ok(())
+    }
+
+    fn load_diagram(&mut self, index: usize) -> Result<Diagram> {
+        if let Some(diagram) = self.diagrams.get(&index) {
+            return Ok(diagram.clone());
+        }
+
+        let dim: usize = from_value(self.stored[index][1]["n"].clone())?;
+        let diagram: Diagram = match dim {
+            0 => {
+                let id: String = from_value(self.stored[index][1]["f"]["id"].clone())?;
+                let id: usize = id.parse().unwrap();
+                self.generators[&id].into()
+            }
+
+            _ => {
+                // Load source
+                let source_index: usize =
+                    from_value(self.stored[index][1]["f"]["source"]["_l"].clone())?;
+                let source = match self.diagrams.get(&source_index) {
+                    Some(source) => source.clone(),
+                    None => self.load_diagram(source_index)?,
+                };
+
+                //log::debug!("source of {} : {:#?}", index, source);
+
+                // Load cospans
+                let cospans_index: usize =
+                    from_value(self.stored[index][1]["f"]["data"]["_l"].clone())?;
+                let cospans_data = self.generate_vec(cospans_index)?;
+
+                let mut cospans: Vec<Cospan> = Vec::new();
+                for v in cospans_data {
+                    let i: usize = from_value(v["_l"].clone())?;
+                    let c = self.load_cospan(i)?;
+                    cospans.push(c);
+                }
+
+                //log::debug!("forming diagram {}", index);
+                DiagramN::new(source, cospans).into()
+            }
+        };
+
+        self.diagrams.insert(index, diagram.clone());
+        Ok(diagram)
+    }
+
+    fn load_cospan(&mut self, index: usize) -> Result<Cospan> {
+        let forward_index = from_value(self.stored[index][1]["f"]["forward_limit"]["_l"].clone())?;
+        let backward_index =
+            from_value(self.stored[index][1]["f"]["backward_limit"]["_l"].clone())?;
+
+        //log::debug!("loading forward rewrite {}", forward_index);
+        let forward = match self.rewrites.get(&forward_index) {
+            Some(f) => f.clone(),
+            None => self.load_rewrite(forward_index)?,
+        };
+        //log::debug!("loading forward rewrite {}", backward_index);
+        let backward = match self.rewrites.get(&backward_index) {
+            Some(b) => b.clone(),
+            None => self.load_rewrite(backward_index)?,
+        };
+
+        Ok(Cospan { forward, backward })
+    }
+
+    fn load_rewrite(&mut self, index: usize) -> Result<Rewrite> {
+        if let Some(rewrite) = self.rewrites.get(&index) {
+            return Ok(rewrite.clone());
+        }
+
+        // Get rewrite information
+        let dim: usize = from_value(self.stored[index][1]["n"].clone())?;
+        let cones_index: usize =
+            from_value(self.stored[index][1]["f"]["components"]["_l"].clone())?;
+        let cones_data = self.generate_vec(cones_index)?;
+
+        let rewrite: Rewrite = match dim {
+            // Case Rewrite0
+            0 => {
+                let i: usize = from_value(cones_data[0]["_l"].clone())?;
+
+                let source: String = from_value(self.stored[i][1]["f"]["source_id"].clone())?;
+                let source: usize = source.parse().unwrap();
+                let source = self.generators[&source].clone();
+
+                let target: String = from_value(self.stored[i][1]["f"]["target_id"].clone())?;
+                let target: usize = target.parse().unwrap();
+                let target = self.generators[&target].clone();
+
+                Rewrite0::new(source, target).into()
+            }
+            // Case RewriteN
+            _ => {
+                let mut cones: Vec<Cone> = Vec::new();
+                let mut acc = 0;
+                for v in cones_data {
+                    let i: usize = from_value(v["_l"].clone())?;
+                    let c = self.load_cone(i)?;
+                    acc = acc + 1;
+                    cones.push(c);
+                }
+                RewriteN::new(dim, cones).into()
+            }
+        };
+
+        self.rewrites.insert(index, rewrite.clone());
+        Ok(rewrite)
+    }
+
+    fn load_cone(&mut self, index: usize) -> Result<Cone> {
+        if let Some(cone) = self.cones.get(&index) {
+            return Ok(cone.clone());
+        }
+
+        // Get cone information
+        let source_index = from_value(self.stored[index][1]["f"]["source_data"]["_l"].clone())?;
+        let target_index = from_value(self.stored[index][1]["f"]["target_data"]["_l"].clone())?;
+        let slices_index = from_value(self.stored[index][1]["f"]["sublimits"]["_l"].clone())?;
+        let cone_index = from_value(self.stored[index][1]["f"]["first"].clone())?;
+
+        // Source and target
+        let source_data = self.generate_vec(source_index)?;
+        let mut source: Vec<Cospan> = Vec::new();
+        for v in source_data {
+            let i: usize = from_value(v["_l"].clone())?;
+            let c = self.load_cospan(i)?;
+            source.push(c);
+        }
+        let target = self.load_cospan(target_index)?;
+
+        // Slices
+        let sublimits = self.generate_vec(slices_index)?;
+        let mut slices: Vec<Rewrite> = Vec::new();
+        for v in sublimits {
+            let i: usize = from_value(v["_l"].clone())?;
+            let c = self.load_rewrite(i)?;
+            slices.push(c);
+        }
+
+        let cone = Cone::new(cone_index, source, target, slices);
+        self.cones.insert(index, cone.clone());
+        Ok(cone)
+    }
+
+    fn load_workspace(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+type Result<T> = std::result::Result<T, OldProofError>;
+
+#[derive(Debug, Error)]
+pub enum OldProofError {
+    #[error("JSON parse failed")]
+    Parse(serde_json::Error),
+    #[error("cannot decode base64")]
+    Decode(base64::DecodeError),
+    #[error("cannot decompress proof string")]
+    Io(std::io::Error),
+    #[error("internal error")]
+    Internal,
+}
+
+impl From<serde_json::Error> for OldProofError {
+    fn from(err: serde_json::Error) -> OldProofError {
+        OldProofError::Parse(err)
+    }
+}
+
+impl From<base64::DecodeError> for OldProofError {
+    fn from(err: base64::DecodeError) -> OldProofError {
+        OldProofError::Decode(err)
+    }
+}
+
+impl From<std::io::Error> for OldProofError {
+    fn from(err: std::io::Error) -> OldProofError {
+        OldProofError::Io(err)
+    }
+}
+
+fn decode_bufreader(bytes: &[u8]) -> io::Result<String> {
+    let mut z = ZlibDecoder::new(&bytes[..]);
+    let mut s = String::new();
+    z.read_to_string(&mut s)?;
+    Ok(s)
+}

--- a/homotopy-core/src/migration.rs
+++ b/homotopy-core/src/migration.rs
@@ -90,7 +90,10 @@ impl OldProof {
     // turns an encoded array at [index] to a vec
     fn generate_vec(&mut self, index: usize) -> Result<Vec<Value>> {
         let map: HashMap<String, Value> = from_value(self.stored[index][1]["f"].clone())?;
-        let mut v: Vec<(String, Value)> = map.into_iter().collect();
+        let mut v: Vec<(usize, Value)> = map
+            .into_iter()
+            .map(|x| (x.0.parse().unwrap(), x.1))
+            .collect();
         v.sort_by(|x, y| x.0.cmp(&y.0));
         let v: Vec<Value> = v.into_iter().map(|x| x.1).collect();
         Ok(v)
@@ -160,7 +163,7 @@ impl OldProof {
                     cospans.push(c);
                 }
 
-                //log::debug!("forming diagram {}", index);
+                log::debug!("forming diagram {}", index);
                 DiagramN::new(source, cospans).into()
             }
         };

--- a/homotopy-web/Cargo.toml
+++ b/homotopy-web/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0.143", features = ["derive"] }
 syn = "1.0.99"
 paste = "1.0.8"
 rmp-serde = "0.15.5"
+serde_json = "1.0.83"
 
 # The `wasm-bindgen` crate provides the bare minimum functionality needed
 # to interact with JavaScript.

--- a/homotopy-web/src/app/project.rs
+++ b/homotopy-web/src/app/project.rs
@@ -30,7 +30,7 @@ pub fn project_view(props: &Props) -> Html {
             <label for="import" class="button">
                 {"Import"}
             </label>
-            <input type="file" accept="application/msgpack,.hom" class="visually-hidden" id="import" onchange={import}/>
+            <input type="file" accept="application/msgpack,.hom,.json" class="visually-hidden" id="import" onchange={import}/>
         </>
     }
 }

--- a/homotopy-web/src/model.rs
+++ b/homotopy-web/src/model.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 pub mod history;
+pub mod migration;
 pub mod proof;
 pub mod serialize;
 
@@ -195,7 +196,12 @@ impl State {
 
             Action::ImportProof(data) => {
                 let (signature, workspace) =
-                    serialize::deserialize(&Vec::<u8>::from(data)).ok_or(ModelError::Import)?;
+                    match serialize::deserialize(&Vec::<u8>::from(data.clone())) {
+                        Some(res) => res,
+                        None => migration::deserialize(&Vec::<u8>::from(data))
+                            .ok_or(ModelError::Import)?,
+                    };
+
                 for g in signature.iter() {
                     g.diagram
                         .check(Mode::Deep)

--- a/homotopy-web/src/model/migration.rs
+++ b/homotopy-web/src/model/migration.rs
@@ -3,7 +3,7 @@ use homotopy_graphics::style::{Color, VertexShape};
 use serde::Deserialize;
 
 use super::{Signature, Workspace};
-use crate::model::proof::{generators::GeneratorInfo, SignatureItem};
+use crate::model::proof::{generators::GeneratorInfo, SignatureItem, View};
 
 #[derive(Deserialize)]
 struct Export {
@@ -57,11 +57,22 @@ fn load(proof: OldProof) -> Option<(Signature, Option<Workspace>)> {
             single_preview: true,
             color,
             shape: VertexShape::default(),
-            diagram: v.diagram,
+            diagram: v.diagram.clone(),
         };
         signature.insert_item(SignatureItem::Item(info));
     }
 
-    let workspace = None;
+    let workspace = match proof.workspace {
+        Some(w) => Some(Workspace {
+            diagram: w.diagram.clone(),
+            path: Default::default(),
+            view: View::new(w.diagram.dimension().min(2) as u8),
+            attach: Default::default(),
+            attachment_highlight: Default::default(),
+            slice_highlight: Default::default(),
+        }),
+        None => None,
+    };
+
     Some((signature, workspace))
 }

--- a/homotopy-web/src/model/migration.rs
+++ b/homotopy-web/src/model/migration.rs
@@ -52,7 +52,7 @@ fn load(proof: OldProof) -> Option<(Signature, Option<Workspace>)> {
         let info = GeneratorInfo {
             generator: v.generator,
             name: v.name,
-            oriented: false,
+            oriented: true,
             invertible: false,
             single_preview: true,
             color,

--- a/homotopy-web/src/model/migration.rs
+++ b/homotopy-web/src/model/migration.rs
@@ -46,7 +46,6 @@ pub fn deserialize(data: &[u8]) -> Option<(Signature, Option<Workspace>)> {
 fn load(proof: OldProof) -> Option<(Signature, Option<Workspace>)> {
     let mut signature: Signature = Default::default();
 
-    // generators gives a sorted list of GeneratorInfos
     for v in proof.generator_info {
         let color: Color = v.color.parse().ok()?;
         let info = GeneratorInfo {

--- a/homotopy-web/src/model/migration.rs
+++ b/homotopy-web/src/model/migration.rs
@@ -1,0 +1,67 @@
+use homotopy_core::migration::OldProof;
+use homotopy_graphics::style::{Color, VertexShape};
+use serde::Deserialize;
+
+use super::{Signature, Workspace};
+use crate::model::proof::{generators::GeneratorInfo, SignatureItem};
+
+#[derive(Deserialize)]
+struct Export {
+    #[serde(rename = "metadata")]
+    _metadata: Metadata,
+    proof: String,
+}
+
+#[derive(Deserialize)]
+struct Metadata {
+    #[serde(rename = "title")]
+    _title: String,
+    #[serde(rename = "author")]
+    _author: String,
+    #[serde(rename = "abstract")]
+    _user_abstract: String,
+}
+
+pub fn deserialize(data: &[u8]) -> Option<(Signature, Option<Workspace>)> {
+    // Deserialize
+    let export: Export = match serde_json::from_slice(data) {
+        Err(error) => {
+            log::error!("Migration tool: cannot load file. Error: {}", error);
+            None
+        }
+        Ok(export) => Some(export),
+    }?;
+
+    let proof = match OldProof::new(&export.proof) {
+        Err(error) => {
+            log::error!("Migration tool: corrupted proof string. Error: {}", error);
+            None
+        }
+        Ok(proof) => Some(proof),
+    }?;
+
+    load(proof)
+}
+
+fn load(proof: OldProof) -> Option<(Signature, Option<Workspace>)> {
+    let mut signature: Signature = Default::default();
+
+    // generators gives a sorted list of GeneratorInfos
+    for v in proof.generator_info {
+        let color: Color = v.color.parse().ok()?;
+        let info = GeneratorInfo {
+            generator: v.generator,
+            name: v.name,
+            oriented: false,
+            invertible: false,
+            single_preview: true,
+            color,
+            shape: VertexShape::default(),
+            diagram: v.diagram,
+        };
+        signature.insert_item(SignatureItem::Item(info));
+    }
+
+    let workspace = None;
+    Some((signature, workspace))
+}

--- a/homotopy-web/src/model/proof.rs
+++ b/homotopy-web/src/model/proof.rs
@@ -64,6 +64,12 @@ impl View {
     const MIN: u8 = 0;
     const MAX: u8 = 4;
 
+    pub fn new(dim: u8) -> Self {
+        Self {
+            dimension: dim.clamp(Self::MIN, Self::MAX),
+        }
+    }
+
     #[must_use]
     pub fn inc(self) -> Self {
         Self {

--- a/homotopy-web/src/model/proof/signature.rs
+++ b/homotopy-web/src/model/proof/signature.rs
@@ -108,6 +108,10 @@ impl Signature {
         self.0.push_onto(self.0.root(), SignatureItem::Item(info));
     }
 
+    pub fn insert_item(&mut self, item: SignatureItem) {
+        self.0.push_onto(self.0.root(), item);
+    }
+
     fn find_node(&self, generator: Generator) -> Option<Node> {
         self.0.iter().find_map(|(node, item)| match item.inner() {
             SignatureItem::Item(info) if info.generator == generator => Some(node),


### PR DESCRIPTION
The migration tool for loading old homotopy.io files
It can:
- load the signature (name, id, colour, etc.) and the current workspace diagram

It cannot:
- load the slices of current workspace and the attaches (takes lots of efforts to implement, with little benefit)