### PR TITLE
add serde default to metadata fields

### DIFF
--- a/homotopy-web/src/model/migration.rs
+++ b/homotopy-web/src/model/migration.rs
@@ -14,10 +14,13 @@ struct Export {
 
 #[derive(Deserialize)]
 struct Metadata {
+    #[serde(default)]
     #[serde(rename = "title")]
     _title: String,
+    #[serde(default)]
     #[serde(rename = "author")]
     _author: String,
+    #[serde(default)]
     #[serde(rename = "abstract")]
     _user_abstract: String,
 }


### PR DESCRIPTION
Now the migration tool can load projects with some of the metadata fields missing.