### PR TITLE
Metadata UI fixes 1

### DIFF
--- a/homotopy-web/src/app/project.rs
+++ b/homotopy-web/src/app/project.rs
@@ -54,12 +54,8 @@ impl Component for ProjectView {
                     type="text"
                     class="metadata_title"
                     name="title"
-                    value= {
-                        let title = ctx.props().metadata.title.clone();
-                        match title {
-                            Some(value) => value,
-                            None => "Title".to_owned(),
-                    }}
+                    placeholder="Title"
+                    value= {ctx.props().metadata.title.clone().unwrap_or_default()}
                     oninput={ctx.link().callback(move |e: InputEvent| {
                         let input: HtmlInputElement = e.target_unchecked_into();
                         Msg::EditMetadata(MetadataEdit::Title(input.value()))
@@ -74,12 +70,8 @@ impl Component for ProjectView {
                     type="text"
                     class="metadata_author"
                     name="Author"
-                    value = {
-                        let author = ctx.props().metadata.author.clone();
-                        match author {
-                            Some(value) => value,
-                            None => "Author".to_owned(),
-                    }}
+                    placeholder="Author"
+                    value = {ctx.props().metadata.author.clone().unwrap_or_default()}
                     oninput={ctx.link().callback(move |e: InputEvent| {
                         let input: HtmlInputElement = e.target_unchecked_into();
                         Msg::EditMetadata(MetadataEdit::Author(input.value()))
@@ -94,12 +86,8 @@ impl Component for ProjectView {
                     type="textarea"
                     class="metadata_abstract"
                     name="Abstract"
-                    value = {
-                        let abstr = ctx.props().metadata.abstr.clone();
-                        match abstr {
-                            Some(value) => value,
-                            None => "Abstract".to_owned(),
-                    }}
+                    placeholder="Abstract"
+                    value = {ctx.props().metadata.abstr.clone().unwrap_or_default()}
                     oninput={ctx.link().callback(move |e: InputEvent| {
                         let input: HtmlInputElement = e.target_unchecked_into();
                         Msg::EditMetadata(MetadataEdit::Abstract(input.value()))

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -405,6 +405,10 @@ button, .button {
   padding: var(--space-1);
 }
 
+.drawer input[type=text]:focus-within {
+  text-decoration: underline;
+}
+
 /* Metadata */
 /* TODO: Wraparound */
 
@@ -528,10 +532,6 @@ button, .button {
 
 .signature__dropzone.drag-over {
   height: var(--signature-height);
-}
-
-.signature__item input[type=text]:focus-within {
-  text-decoration: underline;
 }
 
 .signature__item-child {


### PR DESCRIPTION
I don't mind if this is merged separately from @anastasia-jc's fixes or if her commits are added on top of these.

The fixes for project metadata so far introduced include:
1. Underline for text inputs.
2. Use placeholder text for text inputs.