### PR TITLE
Panic-proofing the tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,6 @@ dependencies = [
  "bimap",
  "cargo-husky",
  "criterion",
- "either",
  "flate2",
  "getrandom",
  "hashconsing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encode_unicode"
@@ -811,6 +811,7 @@ dependencies = [
  "bimap",
  "cargo-husky",
  "criterion",
+ "either",
  "flate2",
  "getrandom",
  "hashconsing",

--- a/homotopy-common/src/idx.rs
+++ b/homotopy-common/src/idx.rs
@@ -89,6 +89,13 @@ macro_rules! declare_idx {
                 }
             }
 
+            #[cfg(feature = "fuzz")]
+            impl<'a> arbitrary::Arbitrary<'a> for $name {
+                fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+                    Ok($crate::idx::Idx::new(u.int_in_range(0..=4095)?))
+                }
+            }
+
             unsafe impl petgraph::graph::IndexType for $name {
                 #[inline(always)]
                 fn new(x: usize) -> Self {

--- a/homotopy-common/src/tree.rs
+++ b/homotopy-common/src/tree.rs
@@ -9,7 +9,6 @@ use crate::{declare_idx, idx::IdxVec};
 
 declare_idx! {
     #[derive(serde::Serialize, serde::Deserialize)]
-    #[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
     pub struct Node = usize;
 }
 

--- a/homotopy-common/src/tree.rs
+++ b/homotopy-common/src/tree.rs
@@ -226,7 +226,7 @@ impl<T> Tree<T> {
         // Don't introduce a cycle
         assert!(self.ancestors_of(parent).all(|ancestor| ancestor != node));
 
-        if node.0 >= self.nodes.len() {
+        if node.0 >= self.nodes.len() || parent.0 >= self.nodes.len() {
             return;
         }
 

--- a/homotopy-common/src/tree.rs
+++ b/homotopy-common/src/tree.rs
@@ -120,19 +120,27 @@ impl<T> Tree<T> {
     }
 
     #[inline]
-    pub fn with<F, U>(&self, node: Node, f: F) -> U
+    pub fn with<F, U>(&self, node: Node, f: F) -> Option<U>
     where
         F: FnOnce(&NodeData<T>) -> U,
     {
-        f(&self.nodes[node])
+        if node.0 < self.nodes.len() {
+            Some(f(&self.nodes[node]))
+        } else {
+            None
+        }
     }
 
     #[inline]
-    pub fn with_mut<F, U>(&mut self, node: Node, f: F) -> U
+    pub fn with_mut<F, U>(&mut self, node: Node, f: F) -> Option<U>
     where
         F: FnOnce(&mut NodeData<T>) -> U,
     {
-        f(&mut self.nodes[node])
+        if node.0 < self.nodes.len() {
+            Some(f(&mut self.nodes[node]))
+        } else {
+            None
+        }
     }
 
     /// Removes `node` from the tree. This is done by disconnecting the subtree rooted at `node`
@@ -143,22 +151,27 @@ impl<T> Tree<T> {
     /// Doing so will free the memory associated with all disconnected components.
     #[inline]
     pub fn remove(&mut self, node: Node) {
-        if let Some(parent) = self.nodes[node].parent {
-            self.nodes[parent].children.retain(|child| *child != node);
+        if node.0 < self.nodes.len() {
+            if let Some(parent) = self.nodes[node].parent {
+                self.nodes[parent].children.retain(|child| *child != node);
+            }
+            self.nodes[node].parent = None;
         }
-
-        self.nodes[node].parent = None;
     }
 
     #[inline]
-    pub fn push_onto(&mut self, node: Node, t: T) -> Node {
-        let id = self.nodes.push(NodeData {
-            data: t,
-            children: vec![],
-            parent: Some(node),
-        });
-        self.nodes[node].children.push(id);
-        id
+    pub fn push_onto(&mut self, node: Node, t: T) -> Option<Node> {
+        if node.0 < self.nodes.len() {
+            let id = self.nodes.push(NodeData {
+                data: t,
+                children: vec![],
+                parent: Some(node),
+            });
+            self.nodes[node].children.push(id);
+            Some(id)
+        } else {
+            None
+        }
     }
 
     /// Returns an iterator of the ancestors of `node`.
@@ -214,6 +227,10 @@ impl<T> Tree<T> {
         // Don't introduce a cycle
         assert!(self.ancestors_of(parent).all(|ancestor| ancestor != node));
 
+        if node.0 >= self.nodes.len() {
+            return;
+        }
+
         if let Some(old_parent) = self.nodes[node].parent {
             self.nodes[old_parent]
                 .children
@@ -239,6 +256,10 @@ impl<T> Tree<T> {
 
         // Fast return when we're trying to reparent a node next to itself
         if node == successor {
+            return;
+        }
+
+        if successor.0 >= self.nodes.len() {
             return;
         }
 
@@ -378,7 +399,7 @@ impl<'a, T> Iterator for AncestorIterator<'a, T> {
     #[inline]
     fn next(&mut self) -> Option<Node> {
         let node = self.current?;
-        self.current = self.tree.with(node, NodeData::parent);
+        self.current = self.tree.with(node, NodeData::parent)?;
         Some(node)
     }
 }

--- a/homotopy-core/Cargo.toml
+++ b/homotopy-core/Cargo.toml
@@ -11,6 +11,7 @@ build = true
 
 [dependencies]
 homotopy-common = { path = "../homotopy-common" }
+either = "1.8.0"
 bimap = "0.6.2"
 getrandom = { version = "0.2.7", features = ["js"] }
 hashconsing = "1.5.1"

--- a/homotopy-core/Cargo.toml
+++ b/homotopy-core/Cargo.toml
@@ -11,7 +11,6 @@ build = true
 
 [dependencies]
 homotopy-common = { path = "../homotopy-common" }
-either = "1.8.0"
 bimap = "0.6.2"
 getrandom = { version = "0.2.7", features = ["js"] }
 hashconsing = "1.5.1"

--- a/homotopy-core/src/attach.rs
+++ b/homotopy-core/src/attach.rs
@@ -104,10 +104,7 @@ where
         }
 
         BoundaryPath(boundary, depth) => {
-            let source: DiagramN = diagram
-                .source()
-                .try_into()
-                .map_err(|e| Either::Right(e))?;
+            let source: DiagramN = diagram.source().try_into().map_err(|e| Either::Right(e))?;
             let (source, offset) =
                 attach_worker(&source, BoundaryPath(boundary, depth - 1), build)?;
 

--- a/homotopy-core/src/attach.rs
+++ b/homotopy-core/src/attach.rs
@@ -82,7 +82,7 @@ where
 {
     match path {
         BoundaryPath(Boundary::Source, 0) => {
-            let mut cospans = build(diagram.source()).map_err(|e| Either::Left(e))?;
+            let mut cospans = build(diagram.source()).map_err(Either::Left)?;
             let mut source = diagram.source();
 
             for cospan in cospans.iter().rev() {
@@ -96,7 +96,7 @@ where
         }
 
         BoundaryPath(Boundary::Target, 0) => {
-            let added_cospans = build(diagram.target()).map_err(|e| Either::Left(e))?;
+            let added_cospans = build(diagram.target()).map_err(Either::Left)?;
             let offset = added_cospans.len();
             let mut cospans = diagram.cospans().to_vec();
             cospans.extend(added_cospans);
@@ -104,7 +104,7 @@ where
         }
 
         BoundaryPath(boundary, depth) => {
-            let source: DiagramN = diagram.source().try_into().map_err(|e| Either::Right(e))?;
+            let source: DiagramN = diagram.source().try_into().map_err(Either::Right)?;
             let (source, offset) =
                 attach_worker(&source, BoundaryPath(boundary, depth - 1), build)?;
 

--- a/homotopy-core/src/common.rs
+++ b/homotopy-core/src/common.rs
@@ -51,10 +51,18 @@ pub type SingularHeight = usize;
 pub type RegularHeight = usize;
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub enum Height {
     Singular(SingularHeight),
     Regular(RegularHeight),
+}
+
+#[cfg(feature = "fuzz")]
+impl<'a> arbitrary::Arbitrary<'a> for Height {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let h = u.int_in_range(0..=1023)?;
+        u.choose(&[Height::Singular(h), Height::Regular(h)])
+            .map(|s| s.clone())
+    }
 }
 
 impl From<Height> for usize {

--- a/homotopy-core/src/complex.rs
+++ b/homotopy-core/src/complex.rs
@@ -43,7 +43,7 @@ pub fn make_complex<const N: usize>(diagram: &Diagram) -> Vec<(Simplex<N>, bool)
             2 => {
                 complex.extend(TRI_ASSEMBLY_ORDER.into_iter().filter_map(|[i, j, k]| {
                     let tri @ [a, b, c] = [cube[i], cube[j], cube[k]];
-                    (a != b && a != c && b != c).then(|| (Simplex::Surface(tri), cube.visible))
+                    (a != b && a != c && b != c).then_some((Simplex::Surface(tri), cube.visible))
                 }));
             }
             _ => (),

--- a/homotopy-core/src/contraction.rs
+++ b/homotopy-core/src/contraction.rs
@@ -85,7 +85,7 @@ impl DiagramN {
         }
 
         attach(self, boundary_path, |slice| {
-            let slice = slice.try_into().map_err(|_d| ContractionError::Invalid)?;
+            let slice = slice.try_into().or(Err(ContractionError::Invalid))?;
             let contract = contract_in_path(&slice, interior_path, height, bias)?;
             let singular = slice.clone().rewrite_forward(&contract).unwrap();
             let normalize = normalization::normalize_singular(&singular.into());
@@ -108,8 +108,9 @@ impl DiagramN {
                 signature,
             )?;
 
-            Ok(vec![cospan])
+            Ok::<_, ContractionError>(vec![cospan])
         })
+        .or(Err(ContractionError::Invalid))
     }
 }
 

--- a/homotopy-core/src/contraction.rs
+++ b/homotopy-core/src/contraction.rs
@@ -84,7 +84,7 @@ impl DiagramN {
             return Err(ContractionError::Invalid);
         }
 
-        attach(self, boundary_path, |slice| {
+        match attach(self, boundary_path, |slice| {
             let slice = slice.try_into().or(Err(ContractionError::Invalid))?;
             let contract = contract_in_path(&slice, interior_path, height, bias)?;
             let singular = slice.clone().rewrite_forward(&contract).unwrap();
@@ -108,9 +108,12 @@ impl DiagramN {
                 signature,
             )?;
 
-            Ok::<_, ContractionError>(vec![cospan])
-        })
-        .or(Err(ContractionError::Invalid))
+            Ok(vec![cospan])
+        }) {
+            Ok(d) => Ok(d),
+            Err(either::Either::Left(e)) => Err(e),
+            Err(either::Either::Right(e)) => panic!("Attach in contract failed due to a dimension error. Please open an issue on GitHub with the action dump. Error: {}", e),
+        }
     }
 }
 

--- a/homotopy-core/src/contraction.rs
+++ b/homotopy-core/src/contraction.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 
 use crate::{
     attach::{attach, BoundaryPath},
-    common::{Boundary, Height, SingularHeight},
+    common::{Boundary, DimensionError, Height, SingularHeight},
     diagram::{Diagram, DiagramN},
     normalization,
     rewrite::{Cone, Cospan, Rewrite, Rewrite0, RewriteN},
@@ -66,6 +66,8 @@ pub enum ContractionError {
     Ambiguous,
     #[error("contraction fails to typecheck: {0}")]
     IllTyped(#[from] TypeError),
+    #[error("invalid boundary path provided to contraction")]
+    Dimension(#[from] DimensionError),
 }
 
 impl DiagramN {
@@ -84,7 +86,7 @@ impl DiagramN {
             return Err(ContractionError::Invalid);
         }
 
-        match attach(self, boundary_path, |slice| {
+        attach(self, boundary_path, |slice| {
             let slice = slice.try_into().or(Err(ContractionError::Invalid))?;
             let contract = contract_in_path(&slice, interior_path, height, bias)?;
             let singular = slice.clone().rewrite_forward(&contract).unwrap();
@@ -109,11 +111,7 @@ impl DiagramN {
             )?;
 
             Ok(vec![cospan])
-        }) {
-            Ok(d) => Ok(d),
-            Err(either::Either::Left(e)) => Err(e),
-            Err(either::Either::Right(e)) => panic!("Attach in contract failed due to a dimension error. Please open an issue on GitHub with the action dump. Error: {}", e),
-        }
+        })
     }
 }
 

--- a/homotopy-core/src/diagram.rs
+++ b/homotopy-core/src/diagram.rs
@@ -457,7 +457,7 @@ impl DiagramN {
         let depth = self
             .dimension()
             .checked_sub(diagram.dimension())
-            .ok_or_else(|| AttachmentError::Dimension(diagram.dimension(), self.dimension()))?;
+            .ok_or(DimensionError)?;
 
         attach(self, BoundaryPath(boundary, depth), |slice| {
             if slice.embeds(&diagram.slice(boundary.flip()).unwrap(), embedding) {
@@ -466,7 +466,6 @@ impl DiagramN {
                 Err(AttachmentError::Incompatible)
             }
         })
-        .or(Err(AttachmentError::Incompatible))
     }
 
     #[must_use]
@@ -668,8 +667,8 @@ pub enum NewDiagramError {
 
 #[derive(Debug, Error)]
 pub enum AttachmentError {
-    #[error("can't attach diagram of dimension {0} to a diagram of dimension {1}")]
-    Dimension(usize, usize),
+    #[error("cannot attach diagram of a higher dimension")]
+    Dimension(#[from] DimensionError),
 
     #[error("failed to attach incompatible diagrams")]
     Incompatible,

--- a/homotopy-core/src/diagram.rs
+++ b/homotopy-core/src/diagram.rs
@@ -466,6 +466,7 @@ impl DiagramN {
                 Err(AttachmentError::Incompatible)
             }
         })
+        .or(Err(AttachmentError::Incompatible))
     }
 
     #[must_use]

--- a/homotopy-core/src/expansion.rs
+++ b/homotopy-core/src/expansion.rs
@@ -52,7 +52,7 @@ impl DiagramN {
     where
         S: Signature,
     {
-        attach(self, boundary_path, |slice| {
+        match attach(self, boundary_path, |slice| {
             let expand: Rewrite = expand_in_path(&slice, interior_path, direction)?;
             let identity = Rewrite::identity(slice.dimension());
             let cospan = match boundary_path.boundary() {
@@ -68,9 +68,12 @@ impl DiagramN {
 
             typecheck_cospan(slice, cospan.clone(), boundary_path.boundary(), signature)?;
 
-            Ok::<_, ExpansionError>(vec![cospan])
-        })
-        .or(Err(ExpansionError::NoComponent))
+            Ok(vec![cospan])
+        }) {
+            Ok(d) => Ok(d),
+            Err(either::Either::Left(e)) => Err(e),
+            Err(either::Either::Right(e)) => panic!("Attach in expand failed due to a dimension error. Please open an issue on GitHub with the action dump. Error: {}", e),
+        }
     }
 }
 

--- a/homotopy-core/src/expansion.rs
+++ b/homotopy-core/src/expansion.rs
@@ -68,8 +68,9 @@ impl DiagramN {
 
             typecheck_cospan(slice, cospan.clone(), boundary_path.boundary(), signature)?;
 
-            Ok(vec![cospan])
+            Ok::<_, ExpansionError>(vec![cospan])
         })
+        .or(Err(ExpansionError::NoComponent))
     }
 }
 

--- a/homotopy-core/src/factorization.rs
+++ b/homotopy-core/src/factorization.rs
@@ -25,11 +25,11 @@ pub fn factorize(f: Rewrite, g: Rewrite, source: Diagram, target: Diagram) -> Fa
             Diagram::Diagram0(s),
             Diagram::Diagram0(t),
         ) => {
-            assert!(f.source() == None || f.source() == Some(s));
-            assert!(g.source() == None || g.source() == Some(t));
+            assert!(f.source().is_none() || f.source() == Some(s));
+            assert!(g.source().is_none() || g.source() == Some(t));
 
             Factorization::Unique(
-                (s == t || s.dimension < t.dimension).then(|| Rewrite0::new(s, t).into()),
+                (s == t || s.dimension < t.dimension).then_some(Rewrite0::new(s, t).into()),
             )
         }
         (

--- a/homotopy-core/src/layout.rs
+++ b/homotopy-core/src/layout.rs
@@ -39,7 +39,7 @@ impl<const N: usize> Layout<N> {
                         Some(key)
                     },
                     |_, _, r| Some((i, r.direction())),
-                    |_, key, r| (r != ExternalRewrite::Flange).then(|| *key),
+                    |_, key, r| (r != ExternalRewrite::Flange).then_some(*key),
                 )?
                 .output;
         }

--- a/homotopy-core/src/mesh.rs
+++ b/homotopy-core/src/mesh.rs
@@ -128,7 +128,7 @@ impl<const N: usize> Mesh<N> {
                 Some(coord)
             },
             |_, _, _| Some(()),
-            |_, _, r| (r != ExternalRewrite::Flange).then(|| ()),
+            |_, _, r| (r != ExternalRewrite::Flange).then_some(()),
         )?;
 
         let mut mesh = Self {

--- a/homotopy-core/src/projection.rs
+++ b/homotopy-core/src/projection.rs
@@ -69,8 +69,8 @@ impl<const N: usize> Projection<N> {
                         v.push(si);
                         Some(v)
                     },
-                    |_, _, r| (i == 0).then(|| r.direction()),
-                    |_, key, r| (i > 0 && r.is_atomic()).then(|| *key),
+                    |_, _, r| (i == 0).then_some(r.direction()),
+                    |_, key, r| (i > 0 && r.is_atomic()).then_some(*key),
                 )?
                 .output;
         }
@@ -247,7 +247,7 @@ impl<const N: usize> Depths<N> {
                         Some(v)
                     },
                     |_, _, _| Some(()),
-                    |_, _, r| r.is_atomic().then(|| ()),
+                    |_, _, r| r.is_atomic().then_some(()),
                 )?
                 .output;
         }

--- a/homotopy-model/src/model/history.rs
+++ b/homotopy-model/src/model/history.rs
@@ -119,20 +119,20 @@ pub enum HistoryError {
 
 impl History {
     #[allow(clippy::option_if_let_else)]
-    pub fn with_proof<F, U>(&self, f: F) -> U
+    pub fn with_proof<F, U>(&self, f: F) -> Option<U>
     where
         F: Fn(&Proof) -> U,
     {
         if let Some(ref overlay) = self.overlay {
-            let mut overlayed = self.snapshots.with(self.current, Clone::clone);
+            let mut overlayed = self.snapshots.with(self.current, Clone::clone)?;
             overlayed.inner_mut().proof = overlay.clone();
-            f(&overlayed)
+            Some(f(&overlayed))
         } else {
             self.with_proof_internal(f)
         }
     }
 
-    pub fn with_proof_internal<F, U>(&self, f: F) -> U
+    pub fn with_proof_internal<F, U>(&self, f: F) -> Option<U>
     where
         F: Fn(&Proof) -> U,
     {
@@ -142,26 +142,32 @@ impl History {
     pub fn add(&mut self, action: super::proof::Action, proof: Proof) {
         if action.relevant() {
             // check if this action has been performed at this state previously
-            let existing = self.with_proof_internal(|n| {
-                n.children().find(|id| {
-                    self.snapshots
-                        .with(*id, |n| n.action.as_ref() == Some(&action))
+            let existing = self
+                .with_proof_internal(|n| {
+                    n.children().find(|id| {
+                        self.snapshots
+                            .with(*id, |n| n.action.as_ref() == Some(&action))
+                            .unwrap_or_default()
+                    })
                 })
-            });
+                .flatten();
             if let Some(child) = existing {
                 // update timestamp and ensure the action was deterministic
-                self.snapshots.with_mut(child, |n| {
-                    assert_eq!(proof.proof, n.proof);
-                    n.touch();
-                });
+                self.snapshots
+                    .with_mut(child, |n| {
+                        assert_eq!(proof.proof, n.proof);
+                        n.touch();
+                    })
+                    .expect("This should always succeed.");
                 self.current = child;
             } else {
                 // fresh action
-                let child = self.snapshots.push_onto(
+                if let Some(child) = self.snapshots.push_onto(
                     self.current,
                     Snapshot::new(Some(action), proof.into_inner().proof),
-                );
-                self.current = child;
+                ) {
+                    self.current = child;
+                }
             }
             self.overlay = None;
         } else {
@@ -172,6 +178,7 @@ impl History {
     pub fn undo(&mut self) -> Result<(), HistoryError> {
         let prev = self
             .with_proof_internal(NodeData::parent)
+            .flatten()
             .ok_or(HistoryError::Undo)?;
         self.overlay = None;
         self.current = prev;
@@ -181,6 +188,7 @@ impl History {
     pub fn redo(&mut self) -> Result<(), HistoryError> {
         let next = self
             .with_proof_internal(NodeData::last)
+            .flatten()
             .ok_or(HistoryError::Redo)?;
         self.overlay = None;
         self.current = next;
@@ -191,7 +199,7 @@ impl History {
         let mut actions: Vec<_> = self
             .snapshots
             .ancestors_of(self.current)
-            .filter_map(|n| self.snapshots.with(n, |s| s.action.clone()))
+            .filter_map(|n| self.snapshots.with(n, |s| s.action.clone()).flatten())
             .collect();
         actions.reverse();
         actions

--- a/homotopy-model/src/model/proof.rs
+++ b/homotopy-model/src/model/proof.rs
@@ -27,9 +27,15 @@ pub mod generators;
 pub mod homotopy;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
 pub struct View {
     dimension: u8,
+}
+
+#[cfg(feature = "fuzz")]
+impl<'a> arbitrary::Arbitrary<'a> for View {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self::new(u.int_in_range(0..=4)?))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -323,7 +329,6 @@ impl ProofState {
                 .workspace
                 .as_ref()
                 .map_or(false, |ws| ws.visible_dimension() > 0),
-            Action::UpdateView(v) => v.dimension <= 4,
             _ => true,
         }
     }

--- a/homotopy-model/src/model/proof.rs
+++ b/homotopy-model/src/model/proof.rs
@@ -779,7 +779,7 @@ impl ProofState {
             for height in &ws.path {
                 (matches!(height, SliceIndex::Boundary(_))
                     || matches!(height, SliceIndex::Interior(Height::Regular(_))))
-                .then(|| ())
+                .then_some(())
                 .ok_or(ModelError::InvalidAction)?;
                 diagram = DiagramN::try_from(diagram)
                     .map_err(ModelError::InvalidSlice)?

--- a/homotopy-model/src/model/proof.rs
+++ b/homotopy-model/src/model/proof.rs
@@ -287,7 +287,11 @@ impl ProofState {
                     selected.boundary == boundary || globularity(&selected.diagram, &ws.diagram)
                 })
             }),
-            Action::TakeIdentityDiagram | Action::ClearWorkspace => self.workspace.is_some(),
+            Action::TakeIdentityDiagram => self
+                .workspace
+                .as_ref()
+                .map_or(false, |w| w.view.dimension < u8::MAX),
+            Action::ClearWorkspace => self.workspace.is_some(),
             Action::Theorem => self
                 .workspace
                 .as_ref()

--- a/homotopy-model/src/model/proof.rs
+++ b/homotopy-model/src/model/proof.rs
@@ -287,11 +287,7 @@ impl ProofState {
                     selected.boundary == boundary || globularity(&selected.diagram, &ws.diagram)
                 })
             }),
-            Action::TakeIdentityDiagram => self
-                .workspace
-                .as_ref()
-                .map_or(false, |w| w.view.dimension < u8::MAX),
-            Action::ClearWorkspace => self.workspace.is_some(),
+            Action::TakeIdentityDiagram | Action::ClearWorkspace => self.workspace.is_some(),
             Action::Theorem => self
                 .workspace
                 .as_ref()
@@ -327,6 +323,7 @@ impl ProofState {
                 .workspace
                 .as_ref()
                 .map_or(false, |ws| ws.visible_dimension() > 0),
+            Action::UpdateView(v) => v.dimension <= 4,
             _ => true,
         }
     }

--- a/homotopy-model/src/model/proof.rs
+++ b/homotopy-model/src/model/proof.rs
@@ -247,7 +247,7 @@ impl ProofState {
             Action::Befoot => self.befoot()?,
             Action::Restrict => self.restrict()?,
             Action::Theorem => self.theorem()?,
-            Action::EditSignature(edit) => self.edit_signature(edit),
+            Action::EditSignature(edit) => self.edit_signature(edit)?,
             Action::FlipBoundary => self.flip_boundary(),
             Action::RecoverBoundary => self.recover_boundary(),
             Action::Imported | Action::Nothing => {}
@@ -328,7 +328,7 @@ impl ProofState {
     }
 
     /// Handler for [Action::EditSignature].
-    fn edit_signature(&mut self, edit: &SignatureEdit) {
+    fn edit_signature(&mut self, edit: &SignatureEdit) -> Result<(), ModelError> {
         // intercept remove events in order to clean-up workspace and boundaries
         if let SignatureEdit::Remove(node) = edit {
             // remove from the workspace
@@ -345,7 +345,7 @@ impl ProofState {
             }
         }
 
-        self.signature.update(edit);
+        self.signature.update(edit)
     }
 
     fn edit_metadata(&mut self, edit: &MetadataEdit) {

--- a/homotopy-model/src/model/proof/signature.rs
+++ b/homotopy-model/src/model/proof/signature.rs
@@ -151,13 +151,15 @@ impl Signature {
 
     pub fn has_descendents_in(&self, node: Node, diagram: &Diagram) -> bool {
         self.0.descendents_of(node).any(|node| {
-            self.0.with(node, |n| {
-                if let SignatureItem::Item(info) = n.inner() {
-                    diagram.generators().contains(&info.generator)
-                } else {
-                    false
-                }
-            })
+            self.0
+                .with(node, |n| {
+                    if let SignatureItem::Item(info) = n.inner() {
+                        diagram.generators().contains(&info.generator)
+                    } else {
+                        false
+                    }
+                })
+                .unwrap_or_default()
         })
     }
 

--- a/homotopy-web/src/app.rs
+++ b/homotopy-web/src/app.rs
@@ -58,7 +58,7 @@ impl Component for App {
         let state = model::State::default();
         // Install the signature stylesheet
         let mut signature_stylesheet = SignatureStylesheet::new();
-        signature_stylesheet.update(state.with_proof(|p| p.signature().clone()));
+        signature_stylesheet.update(state.with_proof(|p| p.signature().clone()).unwrap());
         signature_stylesheet.mount();
 
         Self {
@@ -75,14 +75,22 @@ impl Component for App {
     fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
         match msg {
             Message::Dispatch(action) => {
-                if !self.state.with_proof(|proof| action.is_valid(proof)) {
+                if !self
+                    .state
+                    .with_proof(|proof| action.is_valid(proof))
+                    .unwrap_or_default()
+                {
                     return false;
                 }
 
                 log::info!("Received action: {:?}", action);
 
                 if let model::Action::Proof(ref action) = action {
-                    if self.state.with_proof(|p| p.resets_panzoom(action)) {
+                    if self
+                        .state
+                        .with_proof(|p| p.resets_panzoom(action))
+                        .unwrap_or_default()
+                    {
                         self.panzoom.reset();
                         self.orbit_control.reset();
                     }
@@ -127,7 +135,7 @@ impl Component for App {
                 }
 
                 self.signature_stylesheet
-                    .update(self.state.with_proof(|p| p.signature().clone()));
+                    .update(self.state.with_proof(|p| p.signature().clone()).unwrap());
 
                 true
             }
@@ -157,7 +165,9 @@ impl App {
     }
 
     fn render(ctx: &Context<Self>, state: &model::State) -> Html {
-        let proof = state.with_proof(Clone::clone);
+        let proof = state
+            .with_proof(Clone::clone)
+            .expect("This should always succeed.");
         let dispatch = ctx.link().callback(Message::Dispatch);
         let signature = proof.signature();
 

--- a/homotopy-web/src/app.rs
+++ b/homotopy-web/src/app.rs
@@ -214,7 +214,7 @@ impl App {
                 </div>
                 <div id="about" class="modal">
                     <div class="modal-dialog">
-                        <a href="#">
+                        <a href="#invisible-button">
                             // Empty div to create an invisible button
                             <div class="modal-close"></div>
                         </a>

--- a/homotopy-web/src/app/signature/folder.rs
+++ b/homotopy-web/src/app/signature/folder.rs
@@ -177,31 +177,34 @@ fn render_item(props: &Props, node: Node) -> Html {
                 }
             }
         })
+        .unwrap_or_default()
 }
 
 fn render_children(props: &Props, node: Node) -> Html {
     let contents = props.signature.as_tree();
-    contents.with(node, move |n| match n.inner() {
-        SignatureItem::Folder(info) if info.open => {
-            let children = n.children().map(|child| render_tree(props, child));
-            let class = format!(
-                "signature__branch {}",
-                if n.is_empty() {
-                    "signature__branch-empty"
-                } else {
-                    ""
-                }
-            );
+    contents
+        .with(node, move |n| match n.inner() {
+            SignatureItem::Folder(info) if info.open => {
+                let children = n.children().map(|child| render_tree(props, child));
+                let class = format!(
+                    "signature__branch {}",
+                    if n.is_empty() {
+                        "signature__branch-empty"
+                    } else {
+                        ""
+                    }
+                );
 
-            html! {
-                <ul class={class}>
-                    {for children}
-                    {render_drop_zone(props, node, DropPosition::After)}
-                </ul>
+                html! {
+                    <ul class={class}>
+                        {for children}
+                        {render_drop_zone(props, node, DropPosition::After)}
+                    </ul>
+                }
             }
-        }
-        _ => html! {},
-    })
+            _ => html! {},
+        })
+        .unwrap_or_default()
 }
 
 fn render_tree(props: &Props, node: Node) -> Html {


### PR DESCRIPTION
Having isolated model into its own crate, and having made all the relevant traits compatible with Arbitrary, we can now use a fuzzer to construct action sequences that lead to panics.

This should vastly reduce the ways in which the tool can crash on users.