### PR TITLE
Metadata fix

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -19,7 +19,7 @@ wasm-bindgen --out-dir dist --no-typescript --target web target/wasm32-unknown-u
 
 [tasks.build-wasm-watch]
 run_task = { name = ["build-wasm"] }
-watch = { watch = ["homotopy-common/src", "homotopy-core/src", "homotopy-graphics/src", "homotopy-web/src"] }
+watch = { watch = ["homotopy-common/src", "homotopy-core/src", "homotopy-graphics/src", "homotopy-web/src", "homotopy-model/src", "homotopy-gl/src"] }
 
 [tasks.build-highs]
 script = '''

--- a/homotopy-cli/src/main.rs
+++ b/homotopy-cli/src/main.rs
@@ -22,7 +22,7 @@ struct Opt {
 
 fn import_hom(path: &PathBuf) -> Option<Proof> {
     let data = read(path).ok()?;
-    let (signature, workspace) = match serialize::deserialize(&data) {
+    let ((signature, workspace), metadata) = match serialize::deserialize(&data) {
         Some(res) => res,
         None => migration::deserialize(&data)?,
     };
@@ -36,6 +36,7 @@ fn import_hom(path: &PathBuf) -> Option<Proof> {
     let mut proof: Proof = Default::default();
     proof.signature = signature;
     proof.workspace = workspace;
+    proof.metadata = metadata;
     Some(proof)
 }
 

--- a/homotopy-model/src/model/migration.rs
+++ b/homotopy-model/src/model/migration.rs
@@ -40,8 +40,14 @@ pub fn deserialize(data: &[u8]) -> Option<((Signature, Option<Workspace>), Metad
         Ok(proof) => Some(proof),
     }?;
 
+    let metadata = Metadata {
+        title: (!export.metadata.title.is_empty()).then_some(export.metadata.title),
+        author: (!export.metadata.author.is_empty()).then_some(export.metadata.author),
+        abstr: (!export.metadata.user_abstract.is_empty()).then_some(export.metadata.user_abstract),
+    };
+
     let sw = load(proof)?;
-    Some((sw, export.metadata.into()))
+    Some((sw, metadata))
 }
 
 fn load(proof: OldProof) -> Option<(Signature, Option<Workspace>)> {
@@ -75,14 +81,4 @@ fn load(proof: OldProof) -> Option<(Signature, Option<Workspace>)> {
     };
 
     Some((signature, workspace))
-}
-
-impl Into<Metadata> for OldMetadata {
-    fn into(self) -> Metadata {
-        Metadata {
-            title: (!self.title.is_empty()).then_some(self.title),
-            author: (!self.author.is_empty()).then_some(self.author),
-            abstr: (!self.user_abstract.is_empty()).then_some(self.user_abstract),
-        }
-    }
 }

--- a/homotopy-model/src/model/proof/signature.rs
+++ b/homotopy-model/src/model/proof/signature.rs
@@ -266,7 +266,7 @@ impl From<Tree<SignatureItem>> for Signature {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Metadata {
     pub title: Option<String>,
     pub author: Option<String>,

--- a/homotopy-model/src/model/serialize.rs
+++ b/homotopy-model/src/model/serialize.rs
@@ -12,7 +12,7 @@ use im::Vector;
 use obake::AnyVersion;
 
 use super::{
-    proof::{generators::GeneratorInfo, FolderInfo, SignatureItem, View},
+    proof::{generators::GeneratorInfo, FolderInfo, Metadata, SignatureItem, View},
     Signature, Workspace,
 };
 
@@ -43,6 +43,7 @@ impl From<WorkspaceData!["0.1.0"]> for WorkspaceData!["0.1.2"] {
 #[obake(version("0.1.0"))]
 #[obake(version("0.1.1"))]
 #[obake(version("0.1.2"))]
+#[obake(version("0.1.3"))]  // with metadata
 #[obake(derive(serde::Serialize, serde::Deserialize))]
 #[obake(serde(tag = "version"))]
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -56,6 +57,8 @@ struct Data {
     workspace: Option<WorkspaceData!["0.1.0"]>,
     #[obake(cfg(">=0.1.2"))]
     workspace: Option<WorkspaceData!["0.1.2"]>,
+    #[obake(cfg(">=0.1.3"))]
+    metadata: Metadata,
 }
 
 impl From<Data!["0.1.0"]> for Data!["0.1.1"] {
@@ -78,6 +81,17 @@ impl From<Data!["0.1.1"]> for Data!["0.1.2"] {
             store: from.store,
             signature: from.signature,
             workspace: from.workspace.map(Into::into),
+        }
+    }
+}
+
+impl From<Data!["0.1.2"]> for Data!["0.1.3"] {
+    fn from(from: Data!["0.1.2"]) -> Self {
+        Self {
+            store: from.store,
+            signature: from.signature,
+            workspace: from.workspace,
+            metadata: Default::default(),
         }
     }
 }
@@ -113,6 +127,7 @@ pub fn serialize(signature: Signature, workspace: Option<Workspace>) -> Vec<u8> 
         store: Default::default(),
         signature: Default::default(),
         workspace: Default::default(),
+        metadata: Default::default(),
     };
 
     let mut signature = signature.into_tree();

--- a/homotopy-model/src/model/serialize.rs
+++ b/homotopy-model/src/model/serialize.rs
@@ -43,7 +43,7 @@ impl From<WorkspaceData!["0.1.0"]> for WorkspaceData!["0.1.2"] {
 #[obake(version("0.1.0"))]
 #[obake(version("0.1.1"))]
 #[obake(version("0.1.2"))]
-#[obake(version("0.1.3"))]  // with metadata
+#[obake(version("0.1.3"))] // with metadata
 #[obake(derive(serde::Serialize, serde::Deserialize))]
 #[obake(serde(tag = "version"))]
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
@@ -122,12 +122,16 @@ struct GeneratorData {
     diagram: Key<Diagram>,
 }
 
-pub fn serialize(signature: Signature, workspace: Option<Workspace>) -> Vec<u8> {
+pub fn serialize(
+    signature: Signature,
+    workspace: Option<Workspace>,
+    metadata: Metadata,
+) -> Vec<u8> {
     let mut data = Data {
         store: Default::default(),
         signature: Default::default(),
         workspace: Default::default(),
-        metadata: Default::default(),
+        metadata,
     };
 
     let mut signature = signature.into_tree();
@@ -158,7 +162,7 @@ pub fn serialize(signature: Signature, workspace: Option<Workspace>) -> Vec<u8> 
     rmp_serde::encode::to_vec_named(&data).unwrap()
 }
 
-pub fn deserialize(data: &[u8]) -> Option<(Signature, Option<Workspace>)> {
+pub fn deserialize(data: &[u8]) -> Option<((Signature, Option<Workspace>), Metadata)> {
     // Deserialize with version tag
     let data: AnyVersion<Data> = match rmp_serde::decode::from_slice(data) {
         Err(error) => {
@@ -211,6 +215,5 @@ pub fn deserialize(data: &[u8]) -> Option<(Signature, Option<Workspace>)> {
             slice_highlight: Default::default(),
         });
     }
-
-    Some((signature, workspace))
+    Some(((signature, workspace), data.metadata))
 }

--- a/homotopy-web/src/model.rs
+++ b/homotopy-web/src/model.rs
@@ -195,13 +195,14 @@ impl State {
                 let data = serialize::serialize(
                     self.with_proof(|p| p.signature.clone()),
                     self.with_proof(|p| p.workspace.clone()),
+                    self.with_proof(|p| p.metadata.clone()),
                 );
                 generate_download("homotopy_io_export", "hom", data.as_slice())
                     .map_err(ModelError::Export)?;
             }
 
             Action::ImportProof(data) => {
-                let (signature, workspace) =
+                let ((signature, workspace), metadata) =
                     match serialize::deserialize(&Vec::<u8>::from(data.clone())) {
                         Some(res) => res,
                         None => migration::deserialize(&Vec::<u8>::from(data))
@@ -221,6 +222,7 @@ impl State {
                 let mut proof: Proof = Default::default();
                 proof.signature = signature;
                 proof.workspace = workspace;
+                proof.metadata = metadata;
                 self.history.add(proof::Action::Imported, proof);
             }
 

--- a/homotopy-web/src/model.rs
+++ b/homotopy-web/src/model.rs
@@ -212,7 +212,7 @@ impl State {
                     self.with_proof(|p| p.workspace.clone())
                         .ok_or(ModelError::Internal)?,
                     self.with_proof(|p| p.metadata.clone())
-                        .ok_or(ModelError::Internal)?
+                        .ok_or(ModelError::Internal)?,
                 );
                 generate_download("homotopy_io_export", "hom", data.as_slice())
                     .map_err(ModelError::Export)?;


### PR DESCRIPTION
Now we can serialize, deserialize, and migrate metadata.
I also tweaked the makefile to watch `homotopy-model` and `homotopy-gl`.