### PR TITLE
refactor image export button

### DIFF
--- a/homotopy-model/src/proof.rs
+++ b/homotopy-model/src/proof.rs
@@ -108,8 +108,6 @@ pub struct ProofState {
     pub workspace: Option<Workspace>,
     pub metadata: Metadata,
     boundary: Option<SelectedBoundary>,
-    // If true, signature drawer will draw the image export panel
-    pub show_image_export: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/homotopy-web/src/app/image_export.rs
+++ b/homotopy-web/src/app/image_export.rs
@@ -4,6 +4,7 @@ use crate::{components::settings::Settings, declare_settings, model};
 
 declare_settings! {
     pub struct ImageExportSettings {
+        tikz_show_braidings: bool = true,
         manim_use_opengl: bool = false,
     }
 }
@@ -52,7 +53,7 @@ impl Component for ImageExportView {
                 </p>
             }
         };
-        let tikz = Self::view_tikz(ctx);
+        let tikz = self.view_tikz(ctx);
         let svg = Self::view_svg(ctx);
         let manim = self.view_manim(ctx);
         let stl = Self::view_stl(ctx);
@@ -70,11 +71,18 @@ impl Component for ImageExportView {
 }
 
 impl ImageExportView {
-    fn view_tikz(ctx: &Context<Self>) -> Html {
+    fn view_tikz(&self, ctx: &Context<Self>) -> Html {
         if ctx.props().view_dim == 2 {
             html! {
                 <>
                     <h3>{"Export to TikZ"}</h3>
+                    {
+                        self.view_checkbox(
+                            "Show braidings",
+                            |local| *local.get_tikz_show_braidings(),
+                            ImageExportSettingsDispatch::set_tikz_show_braidings,
+                        )
+                    }
                     <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportTikz)}>{"Export"}</button>
                 </>
             }

--- a/homotopy-web/src/app/image_export.rs
+++ b/homotopy-web/src/app/image_export.rs
@@ -108,8 +108,6 @@ impl ImageExportView {
                             ImageExportSettingsDispatch::set_manim_use_opengl,
                         )
                     }
-                    // For leaving some space between settings and [Export] button
-                    <li class="signature__dropzone"></li>
                     <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportManim)}>{"Export"}</button>
                 </>
             }

--- a/homotopy-web/src/app/image_export.rs
+++ b/homotopy-web/src/app/image_export.rs
@@ -1,6 +1,9 @@
 use yew::prelude::*;
 
-use crate::{components::settings::Settings, declare_settings, model};
+use crate::{
+    components::settings::{KeyStore, Settings},
+    declare_settings, model,
+};
 
 declare_settings! {
     pub struct ImageExportSettings {
@@ -37,8 +40,9 @@ impl Component for ImageExportView {
         }
     }
 
-    fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
-        false
+    fn update(&mut self, _ctx: &Context<Self>, msg: Self::Message) -> bool {
+        self.local.set(&msg);
+        true
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {
@@ -58,13 +62,13 @@ impl Component for ImageExportView {
         let manim = self.view_manim(ctx);
         let stl = Self::view_stl(ctx);
         html! {
-            <>
+            <div class="settings">
                 {default_text}
                 {tikz}
                 {svg}
                 {manim}
                 {stl}
-            </>
+            </div>
 
         }
     }
@@ -76,14 +80,16 @@ impl ImageExportView {
             html! {
                 <>
                     <h3>{"Export to TikZ"}</h3>
-                    {
-                        self.view_checkbox(
-                            "Show braidings",
-                            |local| *local.get_tikz_show_braidings(),
-                            ImageExportSettingsDispatch::set_tikz_show_braidings,
-                        )
-                    }
-                    <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportTikz)}>{"Export"}</button>
+                    <div class="settings__segment">
+                        {
+                            self.view_checkbox(
+                                "Show braidings",
+                                |local| *local.get_tikz_show_braidings(),
+                                ImageExportSettingsDispatch::set_tikz_show_braidings,
+                            )
+                        }
+                        <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportTikz)}>{"Export"}</button>
+                    </div>
                 </>
             }
         } else {
@@ -96,7 +102,9 @@ impl ImageExportView {
             html! {
                 <>
                     <h3>{"Export to SVG"}</h3>
-                    <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportSvg)}>{"Export"}</button>
+                    <div class="settings__segment">
+                        <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportSvg)}>{"Export"}</button>
+                    </div>
                 </>
             }
         } else {
@@ -109,14 +117,16 @@ impl ImageExportView {
             html! {
                 <>
                     <h3>{"Export to Manim"}</h3>
-                    {
-                        self.view_checkbox(
-                            "OpenGL renderer",
-                            |local| *local.get_manim_use_opengl(),
-                            ImageExportSettingsDispatch::set_manim_use_opengl,
-                        )
-                    }
-                    <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportManim)}>{"Export"}</button>
+                    <div class="settings__segment">
+                        {
+                            self.view_checkbox(
+                                "OpenGL renderer",
+                                |local| *local.get_manim_use_opengl(),
+                                ImageExportSettingsDispatch::set_manim_use_opengl,
+                            )
+                        }
+                        <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportManim)}>{"Export"}</button>
+                    </div>
                 </>
             }
         } else {
@@ -129,7 +139,9 @@ impl ImageExportView {
             html! {
                 <>
                     <h3>{"Export to STL"}</h3>
-                    <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportStl)}>{"Export"}</button>
+                    <div class="settings__segment">
+                        <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportStl)}>{"Export"}</button>
+                    </div>
                 </>
             }
         } else {

--- a/homotopy-web/src/app/image_export.rs
+++ b/homotopy-web/src/app/image_export.rs
@@ -76,6 +76,7 @@ impl Component for ImageExportView {
 
 impl ImageExportView {
     fn view_tikz(&self, ctx: &Context<Self>) -> Html {
+        let show_braidings = *self.local.get_tikz_show_braidings();
         if ctx.props().view_dim == 2 {
             html! {
                 <>
@@ -88,7 +89,7 @@ impl ImageExportView {
                                 ImageExportSettingsDispatch::set_tikz_show_braidings,
                             )
                         }
-                        <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportTikz)}>{"Export"}</button>
+                        <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportTikz(show_braidings))}>{"Export"}</button>
                     </div>
                 </>
             }
@@ -113,6 +114,7 @@ impl ImageExportView {
     }
 
     fn view_manim(&self, ctx: &Context<Self>) -> Html {
+        let use_opengl = *self.local.get_manim_use_opengl();
         if ctx.props().view_dim == 2 {
             html! {
                 <>
@@ -125,7 +127,7 @@ impl ImageExportView {
                                 ImageExportSettingsDispatch::set_manim_use_opengl,
                             )
                         }
-                        <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportManim)}>{"Export"}</button>
+                        <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportManim(use_opengl))}>{"Export"}</button>
                     </div>
                 </>
             }

--- a/homotopy-web/src/app/image_export.rs
+++ b/homotopy-web/src/app/image_export.rs
@@ -26,12 +26,24 @@ impl Component for ImageExportView {
     }
 
     fn view(&self, ctx: &Context<Self>) -> Html {
+        let default_text = if ctx.props().view_dim == 2 || ctx.props().view_dim == 3 {
+            Default::default()
+        } else {
+            html! {
+                <p>{
+                    "There is nothing to export. \n
+                    Try creating a 2D/3D diagram or change to 2D/3D view with the view buttons
+                    at the top-right corner."}
+                </p>
+            }
+        };
         let tikz = Self::view_tikz(ctx);
         let svg = Self::view_svg(ctx);
         let manim = Self::view_manim(ctx);
         let stl = Self::view_stl(ctx);
         html! {
             <>
+                {default_text}
                 {tikz}
                 {svg}
                 {manim}

--- a/homotopy-web/src/app/image_export.rs
+++ b/homotopy-web/src/app/image_export.rs
@@ -1,6 +1,12 @@
 use yew::prelude::*;
 
-use crate::model;
+use crate::{components::settings::Settings, declare_settings, model};
+
+declare_settings! {
+    pub struct ImageExportSettings {
+        manim_use_opengl: bool = false,
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Properties)]
 pub struct Props {
@@ -8,17 +14,26 @@ pub struct Props {
     pub view_dim: u8,
 }
 
-#[derive(Debug, Clone)]
-pub enum Message {}
-
-pub struct ImageExportView;
+pub struct ImageExportView {
+    _settings: ImageExportSettings,
+    // Maintain a local copy of the global app settings in order to display the current settings
+    // state correctly.
+    local: ImageExportSettingsKeyStore,
+}
 
 impl Component for ImageExportView {
-    type Message = Message;
+    type Message = ImageExportSettingsMsg;
     type Properties = Props;
 
-    fn create(_ctx: &Context<Self>) -> Self {
-        Self
+    fn create(ctx: &Context<Self>) -> Self {
+        let mut settings = ImageExportSettings::connect(ctx.link().callback(|x| x));
+        // So that we can keep our local copy of the global settings up to date,
+        // we're going to need to subscribe to all changes in the global settings state.
+        settings.subscribe(ImageExportSettings::ALL);
+        Self {
+            _settings: settings,
+            local: Default::default(),
+        }
     }
 
     fn update(&mut self, _ctx: &Context<Self>, _msg: Self::Message) -> bool {
@@ -39,7 +54,7 @@ impl Component for ImageExportView {
         };
         let tikz = Self::view_tikz(ctx);
         let svg = Self::view_svg(ctx);
-        let manim = Self::view_manim(ctx);
+        let manim = self.view_manim(ctx);
         let stl = Self::view_stl(ctx);
         html! {
             <>
@@ -81,11 +96,20 @@ impl ImageExportView {
         }
     }
 
-    fn view_manim(ctx: &Context<Self>) -> Html {
+    fn view_manim(&self, ctx: &Context<Self>) -> Html {
         if ctx.props().view_dim == 2 {
             html! {
                 <>
                     <h3>{"Export to Manim"}</h3>
+                    {
+                        self.view_checkbox(
+                            "OpenGL renderer",
+                            |local| *local.get_manim_use_opengl(),
+                            ImageExportSettingsDispatch::set_manim_use_opengl,
+                        )
+                    }
+                    // For leaving some space between settings and [Export] button
+                    <li class="signature__dropzone"></li>
                     <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportManim)}>{"Export"}</button>
                 </>
             }
@@ -104,6 +128,26 @@ impl ImageExportView {
             }
         } else {
             Default::default()
+        }
+    }
+
+    fn view_checkbox<G, S>(&self, name: &str, getter: G, setter: S) -> Html
+    where
+        G: Fn(&ImageExportSettingsKeyStore) -> bool,
+        S: Fn(&ImageExportSettingsDispatch, bool) + 'static,
+    {
+        let checked = getter(&self.local);
+        let dispatch = ImageExportSettingsDispatch::new();
+
+        html! {
+            <div class="settings__toggle-setting">
+                <input
+                    type="checkbox"
+                    checked={checked}
+                    onclick={Callback::from(move |_| setter(&dispatch, !checked))}
+                />
+                {name}
+            </div>
         }
     }
 }

--- a/homotopy-web/src/app/sidebar.rs
+++ b/homotopy-web/src/app/sidebar.rs
@@ -4,7 +4,7 @@ use yew::prelude::*;
 use yew_macro::function_component;
 
 use crate::{
-    app::{attach::AttachView, image_export::ImageExportView, keybindings::Keybindings},
+    app::{attach::AttachView, keybindings::Keybindings},
     components::{
         icon::{Icon, IconSize},
         Visibility,
@@ -363,25 +363,6 @@ impl Sidebar {
         let model_dispatch = &ctx.props().dispatch;
         let sidebar_dispatch = ctx.link().callback(|x| x);
         let proof = &ctx.props().proof;
-
-        if proof.show_image_export {
-            return html! {
-                <SidebarDrawer
-                    class="dialog"
-                    title="Image export"
-                    model_dispatch={model_dispatch}
-                    sidebar_dispatch={sidebar_dispatch}
-                    initial_width={self.last_drawer_width}
-                    icon="close"
-                    on_click={model::Action::ToggleImageExport}
-                >
-                    <ImageExportView
-                        dispatch={model_dispatch.clone()}
-                        view_dim={proof.workspace().as_ref().unwrap().view.dimension()}
-                    />
-                </SidebarDrawer>
-            };
-        }
 
         let attach_options = proof
             .workspace()

--- a/homotopy-web/src/app/sidebar/buttons.rs
+++ b/homotopy-web/src/app/sidebar/buttons.rs
@@ -110,9 +110,4 @@ declare_sidebar_tools! {
         model::Action::Proof(model::proof::Action::ClearWorkspace),
     }
 
-    BUTTON_IMGEXPORT {
-        "Image export",
-        "download",
-        model::Action::ToggleImageExport,
-    }
 }

--- a/homotopy-web/src/app/sidebar/drawers.rs
+++ b/homotopy-web/src/app/sidebar/drawers.rs
@@ -119,16 +119,6 @@ declare_sidebar_drawers! {
         min_width: 250,
     }
 
-    DRAWER_SETTINGS {
-        "Settings",
-        "settings",
-        "settings",
-        |_, _, _| html! {
-            <SettingsView />
-        },
-        min_width: 250,
-    }
-
     DRAWER_SIGNATURE {
         "Signature",
         "signature",
@@ -154,6 +144,16 @@ declare_sidebar_drawers! {
                 dispatch={dispatch}
                 view_dim={proof.workspace().as_ref().map_or(0, |ws| ws.view.dimension())}
             />
+        },
+        min_width: 250,
+    }
+
+    DRAWER_SETTINGS {
+        "Settings",
+        "settings",
+        "settings",
+        |_, _, _| html! {
+            <SettingsView />
         },
         min_width: 250,
     }

--- a/homotopy-web/src/app/sidebar/drawers.rs
+++ b/homotopy-web/src/app/sidebar/drawers.rs
@@ -158,6 +158,18 @@ declare_sidebar_drawers! {
         min_width: 250,
     }
 
+    DRAWER_IMAGE_EXPORT {
+        "Image export",
+        "ImageExport",
+        "share",
+        |dispatch, proof: &Proof| html! {
+            <ImageExportView
+                dispatch={dispatch}
+                view_dim={proof.workspace().as_ref().map_or(0, |ws| ws.view.dimension())}
+            />
+        },
+    }
+
     #[cfg(debug_assertions)]
     DRAWER_DEBUG {
         "Debug",

--- a/homotopy-web/src/app/sidebar/drawers.rs
+++ b/homotopy-web/src/app/sidebar/drawers.rs
@@ -4,7 +4,10 @@ use super::{DrawerViewSize, Sidebar, SidebarButton, SidebarDrawer, SidebarMsg};
 #[cfg(debug_assertions)]
 use crate::app::debug::DebugView;
 use crate::{
-    app::{project::ProjectView, settings::SettingsView, signature::SignatureView},
+    app::{
+        image_export::ImageExportView, project::ProjectView, settings::SettingsView,
+        signature::SignatureView,
+    },
     components::Visible,
     model::{
         self,
@@ -140,6 +143,19 @@ declare_sidebar_drawers! {
         min_width: 250,
         top_icon: "create_new_folder",
         top_icon_action: |proof: &Proof| model::Action::Proof(Action::EditSignature(SignatureEdit::NewFolder(proof.signature().as_tree().root()))),
+    }
+
+    DRAWER_IMAGE_EXPORT {
+        "Image export",
+        "ImageExport",
+        "output",
+        |dispatch, proof: &Proof, _| html! {
+            <ImageExportView
+                dispatch={dispatch}
+                view_dim={proof.workspace().as_ref().map_or(0, |ws| ws.view.dimension())}
+            />
+        },
+        min_width: 250,
     }
 
     #[cfg(debug_assertions)]

--- a/homotopy-web/src/app/sidebar/drawers.rs
+++ b/homotopy-web/src/app/sidebar/drawers.rs
@@ -158,18 +158,6 @@ declare_sidebar_drawers! {
         min_width: 250,
     }
 
-    DRAWER_IMAGE_EXPORT {
-        "Image export",
-        "ImageExport",
-        "share",
-        |dispatch, proof: &Proof| html! {
-            <ImageExportView
-                dispatch={dispatch}
-                view_dim={proof.workspace().as_ref().map_or(0, |ws| ws.view.dimension())}
-            />
-        },
-    }
-
     #[cfg(debug_assertions)]
     DRAWER_DEBUG {
         "Debug",

--- a/homotopy-web/src/model.rs
+++ b/homotopy-web/src/model.rs
@@ -15,7 +15,6 @@ pub enum Action {
     ImportProof(SerializedData),
     ExportProof,
     ExportActions,
-    ToggleImageExport,
     ExportTikz,
     ExportSvg,
     ExportManim,
@@ -29,9 +28,6 @@ impl Action {
 
         match self {
             Self::Proof(action) => proof.is_valid(action),
-            Self::ToggleImageExport => proof.workspace.as_ref().map_or(false, |ws| {
-                ws.view.dimension() == 2 || ws.view.dimension() == 3
-            }),
             Self::ExportTikz | Self::ExportSvg | Self::ExportManim => proof
                 .workspace
                 .as_ref()
@@ -107,11 +103,6 @@ impl State {
 
                 let mut proof = self.with_proof(Clone::clone).ok_or(ModelError::Internal)?;
                 proof.update(&action).map_err(ModelError::from)?;
-                // Hide image export dialog automatically if view dimension is not 2 or 3.
-                proof.show_image_export = proof.show_image_export
-                    && proof.workspace.as_ref().map_or(false, |ws| {
-                        ws.view.dimension() == 2 || ws.view.dimension() == 3
-                    });
                 self.history.add(action, proof);
             }
 
@@ -275,12 +266,6 @@ impl State {
                         }
                     }
                 };
-            }
-
-            Action::ToggleImageExport => {
-                let mut proof = self.with_proof(Clone::clone).ok_or(ModelError::Internal)?;
-                proof.show_image_export = !proof.show_image_export;
-                self.history.add(proof::Action::Nothing, proof);
             }
         }
 

--- a/homotopy-web/src/model.rs
+++ b/homotopy-web/src/model.rs
@@ -15,9 +15,9 @@ pub enum Action {
     ImportProof(SerializedData),
     ExportProof,
     ExportActions,
-    ExportTikz,
+    ExportTikz(bool),
     ExportSvg,
-    ExportManim,
+    ExportManim(bool),
     ExportStl,
 }
 
@@ -28,7 +28,7 @@ impl Action {
 
         match self {
             Self::Proof(action) => proof.is_valid(action),
-            Self::ExportTikz | Self::ExportSvg | Self::ExportManim => proof
+            Self::ExportTikz(_) | Self::ExportSvg | Self::ExportManim(_) => proof
                 .workspace
                 .as_ref()
                 .map_or(false, |ws| ws.view.dimension() == 2),
@@ -126,7 +126,7 @@ impl State {
                 };
             }
 
-            Action::ExportTikz => {
+            Action::ExportTikz(_) => {
                 let signature = self
                     .with_proof(|p| p.signature.clone())
                     .ok_or(ModelError::Internal)?;
@@ -185,7 +185,7 @@ impl State {
                     .map_err(ModelError::Export)?;
             }
 
-            Action::ExportManim => {
+            Action::ExportManim(use_opengl) => {
                 let signature = self
                     .with_proof(|p| p.signature.clone())
                     .ok_or(ModelError::Internal)?;
@@ -193,7 +193,6 @@ impl State {
                     .with_proof(|p| p.workspace.as_ref().unwrap().visible_diagram())
                     .ok_or(ModelError::Internal)?;
                 let stylesheet = manim::stylesheet(&signature);
-                let use_opengl = false;
                 let data = manim::render(&diagram, &signature, &stylesheet, use_opengl).unwrap();
                 generate_download("homotopy_io_export", "py", data.as_bytes())
                     .map_err(ModelError::Export)?;

--- a/homotopy-web/src/model.rs
+++ b/homotopy-web/src/model.rs
@@ -134,7 +134,7 @@ impl State {
                     .with_proof(|p| p.workspace.as_ref().unwrap().visible_diagram())
                     .ok_or(ModelError::Internal)?;
                 let stylesheet = tikz::stylesheet(&signature);
-                let data = tikz::render(&diagram, &stylesheet, &signature).unwrap();
+                let data = tikz::render(&diagram, &stylesheet, &signature, true).unwrap();
                 generate_download("homotopy_io_export", "tikz", data.as_bytes())
                     .map_err(ModelError::Export)?;
             }

--- a/homotopy-web/src/model.rs
+++ b/homotopy-web/src/model.rs
@@ -126,7 +126,7 @@ impl State {
                 };
             }
 
-            Action::ExportTikz(_) => {
+            Action::ExportTikz(with_braid) => {
                 let signature = self
                     .with_proof(|p| p.signature.clone())
                     .ok_or(ModelError::Internal)?;
@@ -134,7 +134,7 @@ impl State {
                     .with_proof(|p| p.workspace.as_ref().unwrap().visible_diagram())
                     .ok_or(ModelError::Internal)?;
                 let stylesheet = tikz::stylesheet(&signature);
-                let data = tikz::render(&diagram, &stylesheet, &signature, true).unwrap();
+                let data = tikz::render(&diagram, &stylesheet, &signature, with_braid).unwrap();
                 generate_download("homotopy_io_export", "tikz", data.as_bytes())
                     .map_err(ModelError::Export)?;
             }

--- a/homotopy-web/static/styles.css
+++ b/homotopy-web/static/styles.css
@@ -1031,6 +1031,7 @@ svg {
 .settings__toggle-setting {
   display: flex;
   align-items: left;
+  padding-bottom: var(--space-1);
 }
 
 .settings__toggle-setting input {


### PR DESCRIPTION
Refactor image export button so that it's in the top part of the sidebar.
Also added checkboxes for TikZ and Manim export options.