### PR TITLE
Refactored panic handling logic to avoid OOMs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,6 +1044,7 @@ dependencies = [
  "yew",
  "yew-agent",
  "yew-macro",
+ "zip",
 ]
 
 [[package]]
@@ -2392,4 +2393,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]

--- a/homotopy-model/src/history.rs
+++ b/homotopy-model/src/history.rs
@@ -173,6 +173,22 @@ impl History {
         actions
     }
 
+    pub fn get_last_import_segment(&self) -> Vec<super::proof::Action> {
+        let mut actions = Vec::new();
+        for a in self
+            .snapshots
+            .ancestors_of(self.current)
+            .filter_map(|n| self.snapshots.with(n, |s| s.action.clone()).flatten())
+        {
+            actions.push(a.clone());
+            if matches!(a, super::proof::Action::ImportProof(_)) {
+                break;
+            }
+        }
+        actions.reverse();
+        actions
+    }
+
     pub fn last_action(&self) -> Option<super::proof::Action> {
         self.snapshots
             .with(self.current, |s| s.action.clone())

--- a/homotopy-web/Cargo.toml
+++ b/homotopy-web/Cargo.toml
@@ -31,6 +31,7 @@ syn = "1.0.104"
 paste = "1.0.9"
 rmp-serde = "1.1.1"
 serde_json = "1.0.89"
+zip = { version = "0.6.3", default-features = false, features = ["deflate"] }
 
 # The `wasm-bindgen` crate provides the bare minimum functionality needed
 # to interact with JavaScript.

--- a/homotopy-web/src/app.rs
+++ b/homotopy-web/src/app.rs
@@ -348,7 +348,7 @@ impl App {
                             <p>
                                 {"We'll fix the problem in no time!"}
                             </p>
-                            <button onclick={move |_| model::download_actions()}>{"Download action logs"}</button>
+                            <button onclick={move |_| {crate::panic::export_dump(false).unwrap();}}>{"Download action logs"}</button>
                         </div>
                     </div>
                 </div>

--- a/homotopy-web/src/app.rs
+++ b/homotopy-web/src/app.rs
@@ -129,6 +129,9 @@ impl Component for App {
                 self.loading = true;
 
                 ctx.link().send_future(async move {
+                    //TODO: remove this too
+                    std::panic::set_hook(Box::new(crate::panic::panic_handler));
+
                     TimeoutFuture::new(0).await; // TODO: remove this awful hack
                     Message::Dispatch(action)
                 });

--- a/homotopy-web/src/lib.rs
+++ b/homotopy-web/src/lib.rs
@@ -4,16 +4,9 @@ use wasm_bindgen::prelude::*;
 
 mod app;
 mod components;
+mod panic;
 // Model has to be public for tests to work
 pub mod model;
-
-fn panic_handler(info: &std::panic::PanicInfo<'_>) {
-    model::display_panic_message();
-    // This provides better error messages in debug mode.
-    // It's disabled in release mode so it doesn't bloat up the file size.
-    #[cfg(feature = "console_error_panic_hook")]
-    console_error_panic_hook::hook(info);
-}
 
 // This is like the `main` function, except for JavaScript.
 #[wasm_bindgen(start)]
@@ -23,7 +16,7 @@ pub fn main_js() -> Result<(), JsValue> {
     // We must use the yew provided method,
     // otherwise yew will override whatever we
     // set with its own handler at start_app!
-    yew::set_custom_panic_hook(Box::new(panic_handler));
+    yew::set_custom_panic_hook(Box::new(panic::panic_handler));
 
     // check if we are the main/UI thread
     wasm_logger::init(wasm_logger::Config::default());

--- a/homotopy-web/src/model.rs
+++ b/homotopy-web/src/model.rs
@@ -87,8 +87,10 @@ impl State {
                 crate::panic::push_action(&action);
 
                 let mut proof = self.proof().clone();
-                if !proof.update(&action)? {
-                    return Ok(false);
+                let res = proof.update(&action);
+                if matches!(res, Err(_) | Ok(false)) {
+                    crate::panic::pop_action();
+                    return Ok(res?);
                 }
                 self.history.add(action, proof);
                 self.clear_attach();

--- a/homotopy-web/src/model.rs
+++ b/homotopy-web/src/model.rs
@@ -9,10 +9,9 @@ use homotopy_graphics::{manim, stl, svg, tikz};
 use homotopy_model::proof::AttachOption;
 pub use homotopy_model::{history, migration, proof, serialize};
 use im::Vector;
-use js_sys::JsString;
 use serde::Serialize;
 use thiserror::Error;
-use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen::JsCast;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum Action {
@@ -83,16 +82,9 @@ impl State {
     pub fn update(&mut self, action: Action) -> Result<bool, ModelError> {
         match action {
             Action::Proof(action) => {
-                // If we are importing a proof,
-                // might as well forget about all previous actions.
-                // This avoid OOM with multiple imports of big proofs.
-                if matches!(action, proof::Action::ImportProof(_)) {
-                    drop_actions();
-                }
                 // Only exfiltrate proof actions, otherwise
                 // we risk funny business with circular action imports.
-                let data = serde_json::to_string(&action).expect("Failed to serialize action.");
-                push_action(JsString::from(data));
+                crate::panic::push_action(&action);
 
                 let mut proof = self.proof().clone();
                 if !proof.update(&action)? {
@@ -108,14 +100,19 @@ impl State {
                     history::Direction::Linear(Forward) => {
                         self.history.redo()?;
                         if let Some(action) = self.history.last_action() {
-                            let data = serde_json::to_string(&action)
-                                .expect("Failed to serialize action.");
-                            push_action(JsString::from(data));
+                            crate::panic::push_action(&action);
                         }
                     }
                     history::Direction::Linear(Backward) => {
                         self.history.undo()?;
-                        pop_action();
+                        // The action we just undid is an ImportProof
+                        // So we need to reimport the context before
+                        // that into the panic handler.
+                        if !crate::panic::pop_action() {
+                            for a in self.history.get_last_import_segment() {
+                                crate::panic::push_action(&a);
+                            }
+                        }
                     }
                 };
                 self.clear_attach();
@@ -192,11 +189,7 @@ impl State {
             }
 
             Action::ExportActions => {
-                let actions = self.history.get_actions();
-                let payload: (bool, Vec<proof::Action>) = (true, actions);
-                let data = serde_json::to_string(&payload).map_err(|_e| ModelError::Internal)?;
-                generate_download("homotopy_io_actions", "txt", data.as_bytes())
-                    .map_err(ModelError::Export)?;
+                crate::panic::export_dump(true)?;
             }
 
             Action::ExportProof => {
@@ -219,8 +212,7 @@ impl State {
                     actions.len() - 1
                 };
 
-                // Forget the history and start from a fresh proof.
-                self.history = Default::default();
+                // Replay actions in top of workspace
                 let mut proof = self.proof().clone();
                 for a in &actions[..len] {
                     if proof.update(a)? {
@@ -435,27 +427,6 @@ pub fn generate_download(name: &str, ext: &str, data: &[u8]) -> Result<(), wasm_
     a.click();
     a.remove();
     web_sys::Url::revoke_object_url(&url)
-}
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen]
-    pub fn drop_actions();
-
-    #[wasm_bindgen]
-    pub fn push_action(a: JsString);
-
-    #[wasm_bindgen]
-    pub fn pop_action();
-
-    #[wasm_bindgen]
-    pub fn dump_actions() -> JsString;
-
-    #[wasm_bindgen]
-    pub fn download_actions();
-
-    #[wasm_bindgen]
-    pub fn display_panic_message();
 }
 
 fn contains_point(diagram: &Diagram, point: &[Height], embedding: &[RegularHeight]) -> bool {

--- a/homotopy-web/src/panic.rs
+++ b/homotopy-web/src/panic.rs
@@ -1,0 +1,132 @@
+use std::{io::Write, sync::Mutex};
+
+use homotopy_model::proof;
+use wasm_bindgen::prelude::*;
+use zip::write::{FileOptions, ZipWriter};
+
+use crate::model::{generate_download, ModelError};
+
+// This file contains all the disgusting
+// panic handling logic which is responsible
+// for producing crash dumps.
+// Out of sight, out of mind, don't break it.
+pub fn panic_handler(info: &std::panic::PanicInfo<'_>) {
+    display_panic_message();
+
+    // This provides better error messages in debug mode.
+    // It's disabled in release mode so it doesn't bloat up the file size.
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::hook(info);
+}
+
+#[derive(Default)]
+struct CrashDump {
+    actions: Vec<String>,
+    import: Option<Vec<u8>>,
+}
+
+static CRASH_INFO: Mutex<CrashDump> = Mutex::new(CrashDump::new());
+
+impl CrashDump {
+    const fn new() -> Self {
+        Self {
+            actions: Vec::new(),
+            import: None,
+        }
+    }
+
+    fn push_action(&mut self, action: &proof::Action) {
+        if let proof::Action::ImportProof(buf) = action {
+            self.actions.clear();
+            self.import = Some(buf.0.clone());
+        } else {
+            let data = serde_json::to_string(&action).expect("Failed to serialize action.");
+            self.actions.push(data);
+        }
+    }
+
+    fn pop_action(&mut self) -> bool {
+        match (self.actions.pop().is_some(), self.import.is_some()) {
+            (true, _) => true,
+            (false, true) => {
+                self.import = None;
+                false
+            }
+            (false, false) => false,
+        }
+    }
+
+    fn needs_zip(&self) -> bool {
+        self.import.is_some()
+    }
+
+    fn get_dump(&self, safe: bool) -> Option<Vec<u8>> {
+        let mut actions: Vec<u8> = Vec::new();
+        if safe {
+            actions.extend(b"[true,[");
+        } else {
+            actions.extend(b"[false,[");
+        }
+        actions.extend(self.actions.join(",").as_bytes());
+        actions.extend(b"]]");
+
+        if let Some(ibuf) = &self.import {
+            let mut buf: Vec<u8> = vec![0; ibuf.len() + actions.len()];
+            let size = {
+                let mut zip = ZipWriter::new(std::io::Cursor::new(&mut buf[..]));
+                let options =
+                    FileOptions::default().compression_method(zip::CompressionMethod::DEFLATE);
+
+                zip.start_file("crash_last_import.hom", options).ok()?;
+                let mut j = 0;
+                while j < ibuf.len() {
+                    j += zip.write(&ibuf[j..]).ok()?;
+                }
+
+                zip.start_file("crash_action_dump.txt", options).ok()?;
+
+                let mut j = 0;
+                while j < actions.len() {
+                    j += zip.write(&actions[j..]).ok()?;
+                }
+                zip.flush().ok()?;
+                zip.finish().ok()?.position()
+            };
+            buf.resize(size as usize, 0);
+            Some(buf)
+        } else {
+            Some(actions)
+        }
+    }
+}
+
+pub fn push_action(action: &proof::Action) {
+    CRASH_INFO.lock().unwrap().push_action(action);
+}
+
+pub fn pop_action() -> bool {
+    CRASH_INFO.lock().unwrap().pop_action()
+}
+
+pub fn needs_zip() -> bool {
+    CRASH_INFO.lock().unwrap().needs_zip()
+}
+
+pub fn get_dump(safe: bool) -> Option<Vec<u8>> {
+    CRASH_INFO.lock().unwrap().get_dump(safe)
+}
+
+pub fn export_dump(safe: bool) -> Result<(), ModelError> {
+    let data = get_dump(safe).ok_or(ModelError::Internal)?;
+    if needs_zip() {
+        generate_download("homotopy_io_state", "zip", &data).map_err(ModelError::Export)
+    } else {
+        generate_download("homotopy_io_actions", "txt", &data).map_err(ModelError::Export)
+    }
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen]
+    pub fn display_panic_message();
+}

--- a/homotopy-web/static/index.html
+++ b/homotopy-web/static/index.html
@@ -27,7 +27,7 @@
 			setTimeout(() => {
 				window.document.querySelectorAll(".cover-spin").forEach(el => el.remove());
 				window.document.getElementById("panic").style.display = "table";
-			}, 500);
+			}, 250);
 		};
 		window.help=display_panic_message;
 	</script>

--- a/homotopy-web/static/index.html
+++ b/homotopy-web/static/index.html
@@ -23,23 +23,12 @@
         import('./highs.js').then(wasm => wasm.default()).catch(console.log);
     </script>
 	<script>
-		window.action_buffer=[];
-		function drop_actions() {window.action_buffer = [];};
-		function push_action(a) {window.action_buffer.push(a);};
-		function pop_action() {window.action_buffer.pop();};
-		function dump_action_text() {return '[false,['+window.action_buffer.join(',')+']]';};
-		function dump_actions() {return JSON.parse(dump_action_text());};
-		function download_actions() {
-			var link = document.createElement('a');
-			link.setAttribute('download', 'homotopy_io_crash_action_dump.txt');
-			const uri = URL.createObjectURL(new Blob([dump_action_text()]), {type:"application/json"});
-			link.href = uri;
-			document.body.appendChild(link);
-			link.click();
-			link.remove();
-			URL.revokeObjectURL(uri);
+		function display_panic_message() {
+			setTimeout(() => {
+				window.document.querySelectorAll(".cover-spin").forEach(el => el.remove());
+				window.document.getElementById("panic").style.display = "table";
+			}, 500);
 		};
-		function display_panic_message() {window.document.getElementById("panic").style.display = "table";};
 		window.help=display_panic_message;
 	</script>
   <script defer type="module" src="./firebase.js"></script>


### PR DESCRIPTION
This PR refactors significantly the panic handling logic, and the associated code to store action dumps.
It aims to significantly reduce the memory footprint of dumps to avoid problems associated with longrunning usage of the tool, such as in #911.