### PR TITLE
Timeout experiment

### DIFF
--- a/homotopy-common/src/lib.rs
+++ b/homotopy-common/src/lib.rs
@@ -2,5 +2,6 @@ pub mod dense;
 pub mod hash;
 pub mod idx;
 pub mod parity;
+pub mod timeout;
 pub mod tree;
 pub mod union_find;

--- a/homotopy-common/src/timeout.rs
+++ b/homotopy-common/src/timeout.rs
@@ -1,0 +1,26 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static SHOULD_TIMEOUT: AtomicBool = AtomicBool::new(false);
+
+/// Call this anywhere in the codebase
+/// If it returns error, raise it with the ?-operator.
+#[allow(clippy::result_unit_err)]
+pub fn timeout_if_needed() -> Result<(), ()> {
+    if SHOULD_TIMEOUT.load(Ordering::Relaxed) {
+        reset_timeout_state();
+        Err(())
+    } else {
+        Ok(())
+    }
+}
+
+/// Map this to timeout buttons to ask the tool
+/// to quit any heavy calculation at the first chance.
+pub fn timeout_now() {
+    SHOULD_TIMEOUT.store(true, Ordering::Relaxed);
+}
+
+/// Call this at the end of a refresh cycle.
+pub fn reset_timeout_state() {
+    SHOULD_TIMEOUT.store(false, Ordering::Relaxed);
+}

--- a/homotopy-core/src/contraction.rs
+++ b/homotopy-core/src/contraction.rs
@@ -4,7 +4,7 @@ use std::{
     hash::Hash,
 };
 
-use homotopy_common::{declare_idx, hash::FastHashMap, idx::IdxVec};
+use homotopy_common::{declare_idx, hash::FastHashMap, idx::IdxVec, timeout::timeout_if_needed};
 use itertools::Itertools;
 use petgraph::{
     adj::UnweightedList,
@@ -552,6 +552,7 @@ fn colimit_base<Ix: IndexType>(graph: &ContractGraph<Ix>) -> Result<Cocone<Ix>, 
     };
 
     for i in max_dims {
+        timeout_if_needed().or(Err(ContractionError::Invalid))?;
         unify(
             &mut stable,
             i,
@@ -709,6 +710,8 @@ fn colimit_recursive<Ix: IndexType>(
         }
     }
 
+    timeout_if_needed().or(Err(ContractionError::Invalid))?;
+
     // find the colimit of the Δ diagram by computing the quotient graph under strongly-connected
     // components and linearizing
     declare_idx! { struct QuotientIx = DefaultIx; }
@@ -789,6 +792,7 @@ fn colimit_recursive<Ix: IndexType>(
                 )
                 .collect(),
         );
+        timeout_if_needed().or(Err(ContractionError::Invalid))?;
         for scc in &linear_components {
             // get the right-most boundary of this scc
             regular_monotone.push({

--- a/homotopy-model/src/proof.rs
+++ b/homotopy-model/src/proof.rs
@@ -259,6 +259,8 @@ pub enum ProofError {
     ContractionError(#[from] ContractionError),
     #[error("import failed")]
     Import,
+    #[error("timeout")]
+    Timeout,
 }
 
 impl ProofState {

--- a/homotopy-web/src/app.rs
+++ b/homotopy-web/src/app.rs
@@ -214,10 +214,14 @@ impl App {
         };
 
         let spinner = if loading {
-            html! { <div class="cover-spin"></div> }
+            html! {
+                <></>
+            }
         } else {
             html! {}
         };
+
+        homotopy_common::timeout::reset_timeout_state();
 
         html! {
             <main class="app">

--- a/homotopy-web/src/app/sidebar.rs
+++ b/homotopy-web/src/app/sidebar.rs
@@ -348,6 +348,7 @@ impl Component for Sidebar {
                     <a href="#about">
                         <img src="/logo.svg" alt="Homotopy.io logo" class="sidebar__logo" />
                     </a>
+                    <button onclick={move |_| {log::warn!("Received timeout request"); homotopy_common::timeout::timeout_now();}}>{"Q"}</button>
                     {self.nav(ctx)}
                     {self.tools(ctx)}
                 </aside>

--- a/homotopy-web/src/model.rs
+++ b/homotopy-web/src/model.rs
@@ -1,6 +1,6 @@
 pub use history::Proof;
 use history::{History, UndoState};
-use homotopy_common::hash::FastHashSet;
+use homotopy_common::{hash::FastHashSet, timeout::timeout_if_needed};
 use homotopy_core::{
     common::{BoundaryPath, RegularHeight},
     Boundary, Diagram, DiagramN, Height, SliceIndex,
@@ -217,6 +217,7 @@ impl State {
                 // Replay actions in top of workspace
                 let mut proof = self.proof().clone();
                 for a in &actions[..len] {
+                    timeout_if_needed().or(Err(proof::ProofError::Timeout))?;
                     if proof.update(a)? {
                         self.history.add(a.clone(), proof.clone());
                     }


### PR DESCRIPTION
The basic code implementing the idea proposed in #930 is simply realised. However, this still doesn't work as it seems hard to even tell the WASM code that the "quit" event has triggered, as event processing is blocked until the thing we want to kill finishes.