### PR TITLE
Left-to-right tikz exports

### DIFF
--- a/homotopy-web/src/app/image_export.rs
+++ b/homotopy-web/src/app/image_export.rs
@@ -7,6 +7,7 @@ use crate::{
 
 declare_settings! {
     pub struct ImageExportSettings {
+        tikz_leftright_mode: bool = false,
         tikz_show_braidings: bool = true,
         manim_use_opengl: bool = false,
     }
@@ -77,6 +78,7 @@ impl Component for ImageExportView {
 impl ImageExportView {
     fn view_tikz(&self, ctx: &Context<Self>) -> Html {
         let show_braidings = *self.local.get_tikz_show_braidings();
+        let leftright_mode = *self.local.get_tikz_leftright_mode();
         if ctx.props().view_dim == 2 {
             html! {
                 <>
@@ -84,12 +86,19 @@ impl ImageExportView {
                     <div class="settings__segment">
                         {
                             self.view_checkbox(
+                                "Left-right mode",
+                                |local| *local.get_tikz_leftright_mode(),
+                                ImageExportSettingsDispatch::set_tikz_leftright_mode,
+                            )
+                        }
+                        {
+                            self.view_checkbox(
                                 "Show braidings",
                                 |local| *local.get_tikz_show_braidings(),
                                 ImageExportSettingsDispatch::set_tikz_show_braidings,
                             )
                         }
-                        <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportTikz(show_braidings))}>{"Export"}</button>
+                        <button onclick={ctx.props().dispatch.reform(move |_| model::Action::ExportTikz(leftright_mode,show_braidings))}>{"Export"}</button>
                     </div>
                 </>
             }

--- a/homotopy-web/src/model.rs
+++ b/homotopy-web/src/model.rs
@@ -19,7 +19,7 @@ pub enum Action {
     ImportActions(proof::SerializedData),
     ExportProof,
     ExportActions,
-    ExportTikz(bool),
+    ExportTikz(bool, bool),
     ExportSvg,
     ExportManim(bool),
     ExportStl,
@@ -37,7 +37,7 @@ impl Action {
         match self {
             Self::Proof(action) => action.is_valid(proof),
             Self::History(history::Action::Move(dir)) => proof.can_move(dir),
-            Self::ExportTikz(_) | Self::ExportSvg | Self::ExportManim(_) => proof
+            Self::ExportTikz(_, _) | Self::ExportSvg | Self::ExportManim(_) => proof
                 .workspace
                 .as_ref()
                 .map_or(false, |ws| ws.view.dimension() == 2),
@@ -121,11 +121,12 @@ impl State {
                 self.clear_attach();
             }
 
-            Action::ExportTikz(with_braid) => {
+            Action::ExportTikz(leftright, with_braid) => {
                 let signature = &self.proof().signature;
                 let diagram = self.proof().workspace.as_ref().unwrap().visible_diagram();
                 let stylesheet = tikz::stylesheet(signature);
-                let data = tikz::render(&diagram, &stylesheet, signature, with_braid).unwrap();
+                let data =
+                    tikz::render(&diagram, &stylesheet, signature, leftright, with_braid).unwrap();
                 generate_download("homotopy_io_export", "tikz", data.as_bytes())
                     .map_err(ModelError::Export)?;
             }


### PR DESCRIPTION
Add the option to export tikz diagrams with left-to-right reading direction.