### PR TITLE
Fix manim

### DIFF
--- a/homotopy-graphics/src/manim.rs
+++ b/homotopy-graphics/src/manim.rs
@@ -246,9 +246,14 @@ fn render_generic<const N: usize>(
         if i > 0 {
             writeln!(manim, "{INDENT}{INDENT}# Begin scope").unwrap();
             for (d, path) in &layer {
-                writeln!(manim, "{INDENT}{INDENT}wires.add(Intersection(surfaces,self.build_path({path},width=20),color=C[\"generator_{id}_{dim}\"]))",
+                writeln!(manim, "{INDENT}{INDENT}wires.add(Intersection(surfaces,self.build_path({path},width=20),color=C[\"generator_{id}_{dim}_1_{or}\"]))",
                          id=d.generator.id,
                          dim=d.generator.dimension,
+                         or=match d.orientation {
+                            Orientation::Positive => "pos",
+                            Orientation::Negative => "neg",
+                            Orientation::Zero => "zer",
+                         },
                          path=&render_path(path)
                 ).unwrap();
             }
@@ -287,7 +292,7 @@ fn render_generic<const N: usize>(
         );
         writeln!(
             manim,
-            "{ind}{ind}points.add({vertex}.move_to(np.array([{ptx},{pty},1])) # circle_{id}_{dim}",
+            "{ind}{ind}points.add({vertex}).move_to(np.array([{ptx},{pty},1])) # circle_{id}_{dim}",
             ind = INDENT,
             id = d.generator.id,
             dim = d.generator.dimension,


### PR DESCRIPTION
Currently, the `.py` files exported by (the beta version of) homotopy.io contain syntax errors and accesses to nonexisting elements of dictionnaries. I think this should fix it. I am unsure about the saturation to put at intersections though.