### PR TITLE
Add support for importing a proof without replacing the existing one

### DIFF
--- a/homotopy-core/src/diagram.rs
+++ b/homotopy-core/src/diagram.rs
@@ -223,6 +223,16 @@ impl Diagram {
             Self::DiagramN(d) => Self::DiagramN(d.replace(from, to, oriented)),
         }
     }
+
+    #[must_use]
+    pub fn replace_map(&self, f: &dyn Fn(Generator) -> Generator) -> Self {
+        // Q: why require &dyn Fn?
+        // A: recursive calls would produce (infinite) recursive instantiations
+        match self {
+            Self::Diagram0(d) => Self::Diagram0(d.replace_map(f)),
+            Self::DiagramN(d) => Self::DiagramN(d.replace_map(f)),
+        }
+    }
 }
 
 pub(crate) fn globularity(s: &Diagram, t: &Diagram) -> bool {
@@ -304,6 +314,11 @@ impl Diagram0 {
         } else {
             *self
         }
+    }
+
+    #[must_use]
+    pub fn replace_map(&self, f: &dyn Fn(Generator) -> Generator) -> Self {
+        Self::new(f(self.generator), self.orientation)
     }
 
     #[must_use]
@@ -466,6 +481,11 @@ impl DiagramN {
             |d| d.replace(from, to, oriented),
             |r| r.replace(from, to, oriented),
         )
+    }
+
+    #[must_use]
+    pub fn replace_map(&self, f: &dyn Fn(Generator) -> Generator) -> Self {
+        self.map(|d| d.replace_map(f), |r| r.replace_map(f))
     }
 
     pub(crate) fn collect_garbage() {

--- a/homotopy-core/src/rewrite.rs
+++ b/homotopy-core/src/rewrite.rs
@@ -238,6 +238,14 @@ impl Rewrite {
     }
 
     #[must_use]
+    pub fn replace_map(&self, f: &dyn Fn(Generator) -> Generator) -> Self {
+        match self {
+            Self::Rewrite0(r) => Self::Rewrite0(r.replace_map(f)),
+            Self::RewriteN(r) => Self::RewriteN(r.replace_map(f)),
+        }
+    }
+
+    #[must_use]
     pub fn orientation_transform(&self, k: Orientation) -> Self {
         self.orientation_transform_above(k, self.dimension())
     }
@@ -403,6 +411,16 @@ impl Rewrite0 {
                     .filter(|_| !oriented || target.generator != from && target.generator != to)
                     .cloned(),
             ),
+        }
+    }
+
+    #[must_use]
+    pub fn replace_map(&self, f: &dyn Fn(Generator) -> Generator) -> Self {
+        match &self.0 {
+            None => Self(None),
+            Some((source, target, label)) => {
+                Self::new(source.replace_map(f), target.replace_map(f), label.clone())
+            }
         }
     }
 
@@ -599,6 +617,16 @@ impl RewriteN {
             .cones()
             .iter()
             .map(|cone| cone.replace(from, to, oriented))
+            .collect();
+        Self::new(self.dimension(), cones)
+    }
+
+    #[must_use]
+    pub fn replace_map(&self, f: &dyn Fn(Generator) -> Generator) -> Self {
+        let cones = self
+            .cones()
+            .iter()
+            .map(|cone| cone.replace_map(f))
             .collect();
         Self::new(self.dimension(), cones)
     }
@@ -1254,6 +1282,10 @@ impl Cone {
 
     fn replace(&self, from: Generator, to: Generator, oriented: bool) -> Self {
         self.map(|r| r.replace(from, to, oriented))
+    }
+
+    fn replace_map(&self, f: impl Fn(Generator) -> Generator) -> Self {
+        self.map(|r| r.replace_map(&f))
     }
 }
 

--- a/homotopy-model/src/proof.rs
+++ b/homotopy-model/src/proof.rs
@@ -148,7 +148,11 @@ pub enum Action {
 
     Merge(Generator, Generator),
 
+    /// Import a proof, replacing the current signature.
     ImportProof(SerializedData),
+
+    /// Import a proof into a new folder, extending the current signature.
+    ImportProofExtend(SerializedData),
 
     EditSignature(SignatureEdit),
 
@@ -255,7 +259,7 @@ impl Action {
                 .is_some_and(|ws| ws.diagram.dimension() > 0),
             Self::Suspend(_, _) | Self::SuspendSignature => proof.signature.has_generators(),
             Self::Merge(_, _) => true,
-            Self::ImportProof(_) => true,
+            Self::ImportProof(_) | Self::ImportProofExtend(_) => true,
             Self::EditSignature(_) | Self::EditMetadata(_) => true, /* technically the edits could be trivial but do not worry about that for now */
             Self::FlipBoundary | Self::RecoverBoundary => proof.boundary.is_some(),
             Self::Stash => proof.workspace.is_some(),
@@ -355,6 +359,7 @@ impl ProofState {
             Action::StashPop => self.stash_pop(),
             Action::StashApply => self.stash_apply(),
             Action::ImportProof(data) => self.import_proof(data)?,
+            Action::ImportProofExtend(data) => self.import_proof_extend(data)?,
             Action::EditMetadata(edit) => self.edit_metadata(edit),
             Action::Nothing => false,
         };
@@ -971,6 +976,20 @@ impl ProofState {
         self.metadata = metadata;
         self.boundary = None;
         self.stash = Vector::new();
+        Ok(true)
+    }
+
+    /// Handler for [Action::ImportProofExtend].
+    fn import_proof_extend(&mut self, data: &SerializedData) -> Result<bool, ProofError> {
+        let ((signature, _), metadata) = serialize::deserialize(&data.0)
+            .or_else(|| migration::deserialize(&data.0))
+            .ok_or(ProofError::Import)?;
+        for info in signature.iter() {
+            info.diagram
+                .check(true)
+                .map_err(|_err| ProofError::Import)?;
+        }
+        self.signature.union_signature(signature, metadata);
         Ok(true)
     }
 

--- a/homotopy-model/src/proof/signature.rs
+++ b/homotopy-model/src/proof/signature.rs
@@ -1,6 +1,9 @@
 use std::{collections::VecDeque, str::FromStr};
 
-use homotopy_common::tree::{Node, Tree};
+use homotopy_common::{
+    hash::FastHashMap,
+    tree::{Node, Tree},
+};
 use homotopy_core::{
     diagram::NewDiagramError,
     signature::{Invertibility, Signature as _},
@@ -215,6 +218,79 @@ impl Signature {
     pub fn remove(&mut self, generator: Generator) {
         if let Some(node) = self.find_node(generator) {
             self.0.remove(node);
+        }
+    }
+
+    /// Disjoint union this signature with another one, adding its contents to a new folder.
+    pub(crate) fn union_signature(&mut self, other: Self, metadata: Metadata) {
+        // We cannot naively copy the other signature, because its
+        // Node-s, folder IDs, and Generator-s may conflict with our
+        // existing IDs. Thus we need to generate fresh IDs ("here")
+        // and then replace those within the other signature ("there")
+        // as we add its items to this one.
+
+        // First, create fresh generator IDs for each generator in the source.
+        let mut generator_there_to_here = FastHashMap::<Generator, Generator>::default();
+        for (generator_there, id_here) in other.generators().zip(self.next_generator_id()..) {
+            generator_there_to_here.insert(
+                generator_there,
+                Generator::new(id_here, generator_there.dimension),
+            );
+        }
+
+        // Then, replace all generators in parallel, and create fresh folder IDs.
+        let mut tree_internally_here = other.0.map(|node| match node {
+            SignatureItem::Folder(mut info) => {
+                info.id = self.next_folder_id();
+                SignatureItem::Folder(info)
+            }
+            SignatureItem::Item(mut info) => {
+                if let Some(&generator_here) = generator_there_to_here.get(&info.generator) {
+                    info.generator = generator_here;
+                } else {
+                    tracing::error!("Generator {:?} not represented here", info.generator);
+                }
+
+                // It is important to substitute in parallel so that
+                // there is never a mix of old and new generators in
+                // the diagram.
+                info.diagram = info.diagram.replace_map(&|gen_there| {
+                    if let Some(&gen_here) = generator_there_to_here.get(&gen_there) {
+                        gen_here
+                    } else {
+                        // We are replacing all generators in the
+                        // imported signature with fresh generators,
+                        // so all of them should be represented.
+                        tracing::error!(
+                            "Generator {:?} in diagram not represented here",
+                            gen_there
+                        );
+                        gen_there
+                    }
+                });
+
+                SignatureItem::Item(info)
+            }
+        });
+
+        // Then merge the tree into the new folder.
+        let mut node_there_to_here = FastHashMap::<Node, Node>::default();
+        if let Some(info) = tree_internally_here.get_mut(tree_internally_here.root()) {
+            if let SignatureItem::Folder(folder) = info.inner_mut() {
+                folder.name = metadata
+                    .title
+                    .unwrap_or_else(|| "Imported folder".to_owned());
+            }
+        }
+
+        for (node_there, info) in tree_internally_here.iter() {
+            let parent_here = info
+                .parent()
+                .and_then(|parent| node_there_to_here.get(&parent).copied())
+                .unwrap_or_else(|| self.0.root());
+            if let Some(node_here) = self.0.push_onto(parent_here, info.inner().clone()) {
+                node_there_to_here.insert(node_there, node_here);
+            }
         }
     }
 

--- a/homotopy-model/src/proof/signature.rs
+++ b/homotopy-model/src/proof/signature.rs
@@ -239,9 +239,10 @@ impl Signature {
         }
 
         // Then, replace all generators in parallel, and create fresh folder IDs.
+        let mut folder_ids = (self.next_folder_id()..).into_iter();
         let mut tree_internally_here = other.0.map(|node| match node {
             SignatureItem::Folder(mut info) => {
-                info.id = self.next_folder_id();
+                info.id = folder_ids.next().unwrap_or_default();
                 SignatureItem::Folder(info)
             }
             SignatureItem::Item(mut info) => {

--- a/homotopy-web/src/app/project.rs
+++ b/homotopy-web/src/app/project.rs
@@ -15,6 +15,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Msg {
     ImportProof(File),
+    ImportProofExtend(File),
     EditMetadata(MetadataEdit),
     Noop,
 }
@@ -49,6 +50,14 @@ impl Component for ProjectView {
                 Msg::Noop
             }
         });
+        let import_extend = ctx.link().callback(|e: Event| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            if let Some(filelist) = input.files() {
+                Msg::ImportProofExtend(filelist.get(0).unwrap())
+            } else {
+                Msg::Noop
+            }
+        });
 
         html! {
             <>
@@ -57,6 +66,10 @@ impl Component for ProjectView {
                     {"Import"}
                 </label>
                 <input type="file" accept="application/msgpack,application/octet-stream,application/zip,.hom,.json,.zip" class="visually-hidden" id="import" onchange={import}/>
+                <label for="import-extend" class="button">
+                    {"Import (Extend)"}
+                </label>
+                <input type="file" accept="application/msgpack,application/octet-stream,application/zip,.hom,.json,.zip" class="visually-hidden" id="import-extend" onchange={import_extend}/>
                 <div class="metadata__details">
                     <TexSpan
                         class="metadata__title"
@@ -104,8 +117,9 @@ impl Component for ProjectView {
 
     fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
         let dispatch = &ctx.props().dispatch;
+        let is_extend = matches!(&msg, Msg::ImportProofExtend(_));
         match msg {
-            Msg::ImportProof(file) => {
+            Msg::ImportProof(file) | Msg::ImportProofExtend(file) => {
                 let is_zip = std::path::Path::new(&file.name())
                     .extension()
                     .map_or(false, |ext| ext.eq_ignore_ascii_case("zip"));
@@ -141,7 +155,12 @@ impl Component for ProjectView {
                             })
                             .flatten()
                             .unwrap_or(data);
-                        dispatch.emit(model::Action::Proof(model::proof::Action::ImportProof(serialized.into())));
+                        dispatch.emit(model::Action::Proof(
+                            if is_extend {
+                                model::proof::Action::ImportProofExtend(serialized.into())
+                            } else {
+                                model::proof::Action::ImportProof(serialized.into())
+                            }));
                     }),
                 );
                 self.reader = Some(task);


### PR DESCRIPTION
In other words, this implements part of #523. #1031 introduced merging generators, so in aggregate I believe we have a full implementation of #523.

The backend implementation takes the other signature, creates new generator IDs for each generator in it, then parallel-substitutes those into the diagrams of the generators. Finally, the other signature is merged into this one, renaming the root folder to the title of the imported project.

The UI is currently an extra button in the "Project" tab titled "Import (Extend)," which looks completely hideous but is all I need. My personal preference would be an extra button at the top of the "Signature" tab, but this seems infeasible with the current code?